### PR TITLE
Remove leftover parent theme cookies banner

### DIFF
--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -5,7 +5,7 @@ From https://github.com/nonhermitian/qiskit_sphinx_theme.
 """
 from os import path
 
-__version__ = '1.7.4'
+__version__ = '1.7.5'
 __version_full__ = __version__
 
 

--- a/qiskit_sphinx_theme/cookie_banner.html
+++ b/qiskit_sphinx_theme/cookie_banner.html
@@ -1,6 +1,0 @@
-<div class="cookie-banner-wrapper">
-  <div class="container">
-    <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="{{ pathto('_static/images/pytorch-x.svg', 1) }}">
-  </div>
-</div>

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -257,8 +257,6 @@
 
 {%- block footer %} {% endblock %}
 
-{% include "cookie_banner.html" %}
-
   <div>
     <br>
   </div>

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
 
 setup(
     name = 'qiskit_sphinx_theme',
-    version = '1.7.4',
+    version = '1.7.5',
     author = 'nonhermitian',
     author_email= 'nonhermitian@gmail.com',
     url="https://github.com/Qiskit/qiskit_sphinx_theme",


### PR DESCRIPTION
Removes leftover Facebook cookies banner from parent pytorch theme.  This was never used anyway.

Also bumps to 1.7.5 so we can release and get rid of it in our projects.