### PR TITLE
Increase language selector visibility

### DIFF
--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,8 +1,7 @@
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
-    <span class="fa fa-book"> {{ _('You are viewing') }}</span>
-    lang: {{ version_label }}
-    <span class="fa fa-caret-down"></span>
+    <span class="rst-current-version-label">{{ version_label }}</span>
+    <span class="rst-versions-dropdown-icon"></span>
   </span>
   <div class="rst-other-versions">
     {% if translations %}

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,3 +1,5 @@
+<!-- This file actually lives in the qiskit/qiskit repository but it is also
+provided here for testing the language selector. -->
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
     <span class="rst-current-version-label">{{ version_label }}</span>

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -12,6 +12,16 @@
       {% endfor %}
     </dl>
     {% endif %}
+    <!-- Uncomment the following and for demo purposes. -->
+    <!--
+    <dl>
+      <dt>Languages</dt>
+      <dd><a class="version" href="#">English</a></dd>
+      <dd><a class="version" href="#">Japanese</a></dd>
+      <dd><a class="version" href="#">Korean</a></dd>
+      <dd><a class="version" href="#">Spanish</a></dd>
+    </dl>
+    -->
   </div>
   <script>
     jQuery('.version').click((evt) => {

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -119,6 +119,8 @@
 
     {# SIDE NAV, TOGGLES ON MOBILE #}
 
+    {% include "versions.html" %}
+
     <div class="table-of-contents-link-wrapper">
       <span>Table of Contents</span>
       <a href="#" class="toggle-table-of-contents" data-behavior="toggle-table-of-contents"></a>
@@ -215,8 +217,6 @@
         </div>
       </section>
     </div>
-
-  {% include "versions.html" %}
 
   {% if not embedded %}
 

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -164,45 +164,70 @@ img {
 }
 
 .rst-versions {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100% !important;
-  color: #fcfcfc;
-  background: #1f1d1d;
-  font-family: var(--font-family-sans-serif);
-  z-index: 400;
+  border-bottom: solid 2px var(--purple);
+  background-color: #f3f4f7;
+}
+
+@media screen and (min-width: 1101px) {
+  .rst-versions {
+    width: 25%;
+    float: left;
+  }
 }
 
 .rst-versions.shift-up {
   height: auto;
   max-height: 100%;
-  overflow-y: scroll;
-  width: auto;
+  overflow-y: auto;
+}
+
+.rst-versions-dropdown-icon {
+  background-image: url("../images/chevron-down-grey.svg");
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 18px 18px;
+  width: 30px;
+}
+
+.rst-versions .rst-other-versions {
+  display: none;
+  position: static;
+  font-size: 90%;
+  padding: 0 12px 0 1.875rem;
+  background-color: #f3f4f7;
+}
+
+@media screen and (min-width: 1101px) {
+  .rst-versions .rst-other-versions {
+    width: 25%;
+    float: left;
+    position: absolute; /* this is for removing it from the flow
+                           and converting it to an overlying layer */
+    z-index: 400;
+    border-bottom: solid 2px var(--purple);
+  }
+}
+
+.rst-versions .rst-other-versions dt {
+  padding-bottom: 0.5rem;
 }
 
 .rst-versions .rst-other-versions dd a {
   display: inline-block;
   padding: 6px;
-  color: #fcfcfc;
-}
-
-.rst-versions .rst-other-versions {
-  font-size: 90%;
-  padding: 12px;
-  color: #DDE1E6;
-  display: none;
 }
 
 .rst-versions .rst-current-version {
-  padding: 12px;
-  background-color: #c7c7c7;
-  display: block;
-  text-align: right;
-  font-size: 90%;
+  display: flex;
+  justify-content: space-between;
+  padding: 1.25rem 21px 1.25rem 1.875rem;
   cursor: pointer;
-  color: #31135e;
   *zoom: 1;
+}
+
+.rst-versions .rst-current-version > * {
+  font-size: 1.25rem;
+  line-height: 1.5rem;
 }
 
 .rst-content .sidebar {
@@ -11696,7 +11721,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 }
 @media screen and (min-width: 1101px) {
   .pytorch-content-wrap {
-    padding-top: 45px;
     float: left;
     width: 100%;
     display: block;
@@ -11796,6 +11820,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   background-color: #f3f4f7;
   color: #262626;
   overflow: scroll;
+  clear: both;
 }
 @media screen and (min-width: 1101px) {
   .pytorch-left-menu {

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -175,6 +175,12 @@ img {
   }
 }
 
+@media screen and (min-width: 1600px) {
+  .rst-versions {
+    width: 350px;
+  }
+}
+
 .rst-versions.shift-up {
   height: auto;
   max-height: 100%;
@@ -205,6 +211,12 @@ img {
                            and converting it to an overlying layer */
     z-index: 400;
     border-bottom: solid 2px var(--purple);
+  }
+}
+
+@media screen and (min-width: 1600px) {
+  .rst-versions .rst-other-versions {
+    width: 350px;
   }
 }
 


### PR DESCRIPTION
Fixes qiskit/qiskit.org#1364

The PR tries to mitigate the lack of visibility of the language selector reported in qiskit/qiskit.org#1364 Although the selector is not sticky, it is better now in a more visible location.

For wide screens:
![Collapsed selector is now on the top left area, stacked on the TOC](https://user-images.githubusercontent.com/757942/108206495-76a83b80-70f4-11eb-88e0-8db1e35cebf5.png)

![Expanded selector shows the different language options](https://user-images.githubusercontent.com/757942/108206663-b1aa6f00-70f4-11eb-92b0-67f75f4aa123.png)

For mobile screens:
![The collapsed selector stacks on top of the collapsed TOC](https://user-images.githubusercontent.com/757942/108206844-f6cea100-70f4-11eb-8ab8-f822b59b006e.png)

![The expanded selector push the rest of the content down](https://user-images.githubusercontent.com/757942/108206961-19f95080-70f5-11eb-8715-8db2194dbe9a.png)




