### PR TITLE
Fix the anchor links in the theme CSS

### DIFF
--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -3,7 +3,7 @@
 """
 from os import path
 
-__version__ = '1.8.4'
+__version__ = '1.8.5'
 __version_full__ = __version__
 
 

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -10571,9 +10571,10 @@ pre {
 }
 
 a.headerlink {
-  color: #fff !important;
-  font-size: 0.8em;
+  color: #de905d !important;
+  font-size: 0.85em;
   padding: 0 4px 0 4px;
+  margin-right: -10px;
 }
 
 a.headerlink:hover{
@@ -12552,4 +12553,12 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   text-decoration: none;
 }
 
+.viewcode-link {
+  font-size: 0.875rem;
+  color: #979797;
+  letter-spacing: 0;
+  line-height: 1.0rem;
+  text-transform: uppercase;
+  padding-right: 5px;
+}
 /*# sourceMappingURL=theme.css.map */

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
 
 setup(
     name = 'qiskit_sphinx_theme',
-    version = '1.8.4',
+    version = '1.8.5',
     author = 'nonhermitian',
     author_email= 'nonhermitian@gmail.com',
     url="https://github.com/Qiskit/qiskit_sphinx_theme",


### PR DESCRIPTION
Fixes the anchor links so that they are not hidden under the `[SOURCE]` links and are not invisible (white).