### PR TITLE
Fix search.html with newer sphinx versions

### DIFF
--- a/qiskit_sphinx_theme/search.html
+++ b/qiskit_sphinx_theme/search.html
@@ -10,6 +10,7 @@
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
+{% set script_files = script_files + ['_static/language_data.js'] %}
 {% block footer %}
   <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
   {{ super() }}


### PR DESCRIPTION
This commit fixes an issue with search.html when building with newer
versions of sphinx. Since the release of sphinx 3.4.0 the search bar
has not worked when using the qiskit_sphinx_theme package. This is
because we were not loading a required script to make the search bar
work with the new sphinx theme. This was done in the upstream
pytorch_sphinx_theme package with:

https://github.com/pytorch/pytorch_sphinx_theme/commit/d033830511a1792c75db70fb97816a7fc29b7c8b

which looks like it was itself ported from the sphinx-rtd-theme package
which fixed this same issue with:

https://github.com/readthedocs/sphinx_rtd_theme/pull/1021

This is just porting that change to qiskit_sphinx_theme which at least
fixes the search bar in local builds for me.