### PR TITLE
Remove overlap between titles on tables

### DIFF
--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -40,15 +40,12 @@
 .wy-table-responsive {
   margin-bottom: 24px;
   max-width: 100%;
-  overflow: auto;
+  max-height: 40rem;
+  overflow: scroll;
 }
 
 .wy-table-responsive table {
   margin-bottom: 0 !important;
-}
-
-article.pytorch-article .wy-table-responsive table {
-width: 100%;
 }
 
 .wy-table-responsive table thead{


### PR DESCRIPTION
Fix #35 

To resolve this issue I've follow what was decided for qiskit.org (go to [this section](https://qiskit.org/events/seminar-series/#:~:text=Past%20Quantum%20Seminars) in a small screen and see the scroll) to start unifying styles. Instead of wrapping the titles on the header, I've set a scroll bar.

Notice that I've also set a max heigh to the table to be able to see the horizontal scroll, if you think we should show all the table, just let me know and I will revert that change:
<img width="875" alt="Captura de pantalla 2021-12-14 a las 13 33 14" src="https://user-images.githubusercontent.com/17231966/146017734-69039245-b02e-4614-acab-62046c2dcb1e.png">

Other useful comment:
- The page where I've tested the code doesn't belongs to this repo and that is why I took screenshots instead of uploading that code. To see the scrolls with another example, go to `/_build/html/lists_tables.html#toc-entry-15` with small screen after building the docs

