### PR TITLE
Add segment analytics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,3 +145,9 @@ html_theme_options = {
 }
 
 autoclass_content = 'both'
+
+# qiskit package specific variables
+html_context = {
+    'repo_name': 'Example Repo',
+    'analytics_enabled': True
+}

--- a/qiskit_sphinx_theme/footer.html
+++ b/qiskit_sphinx_theme/footer.html
@@ -14,9 +14,9 @@
 
     <hr class="helpful-hr hr-top">
       <div class="helpful-container">
-        <div class="helpful-question">Was this helpful?</div>
-        <div class="helpful-question yes-link" data-behavior="was-this-helpful-event" data-response="yes">Yes</div>
-        <div class="helpful-question no-link" data-behavior="was-this-helpful-event" data-response="no">No</div>
+        <div class="helpful-question">Was this page helpful?</div>
+        <a class="helpful-question yes-link" data-behavior="was-this-helpful-event" onclick="window.trackCta('Helpful - yes')">Yes</a>
+        <a class="helpful-question no-link" data-behavior="was-this-helpful-event" onclick="window.trackCta('Helpful - no')">No</a>
         <div class="was-helpful-thank-you">Thank you</div>
       </div>
     <hr class="helpful-hr hr-bottom"/>

--- a/qiskit_sphinx_theme/footer.html
+++ b/qiskit_sphinx_theme/footer.html
@@ -10,7 +10,7 @@
     </div>
   {% endif %}
 
-  {% if theme_pytorch_project == 'tutorials' %}
+  {% if analytics_enabled %}
 
     <hr class="helpful-hr hr-top">
       <div class="helpful-container">
@@ -20,11 +20,7 @@
         <div class="was-helpful-thank-you">Thank you</div>
       </div>
     <hr class="helpful-hr hr-bottom"/>
-
-  {% else %}
-
-    <hr>
-
+  
   {% endif %}
 
   <div role="contentinfo">

--- a/qiskit_sphinx_theme/footer.html
+++ b/qiskit_sphinx_theme/footer.html
@@ -15,9 +15,9 @@
     <hr class="helpful-hr hr-top">
       <div class="helpful-container">
         <div class="helpful-question">Was this page helpful?</div>
-        <a class="helpful-question yes-link" data-behavior="was-this-helpful-event" onclick="window.trackCta('Helpful - yes')">Yes</a>
-        <a class="helpful-question no-link" data-behavior="was-this-helpful-event" onclick="window.trackCta('Helpful - no')">No</a>
-        <div class="was-helpful-thank-you">Thank you</div>
+        <a class="helpful-question yes-link" onclick="clicked('yes')">Yes</a>
+        <a class="helpful-question no-link" onclick="clicked('no')">No</a>
+        <div class="was-helpful-thank-you" id="was-helpful-thank-you">Thank you!</div>
       </div>
     <hr class="helpful-hr hr-bottom"/>
   
@@ -64,4 +64,11 @@
   {%- block extrafooter %} {% endblock %}
 
 </footer>
+
+<script>
+  function clicked(ctaType) {
+    document.getElementById('was-helpful-thank-you').style.visibility = 'visible';
+    window.trackCta(`Helpful - ${ctaType}`);
+  }
+  </script>
 

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -65,7 +65,7 @@
             pageInfo: {
               productTitle: 'IBM Q Experience',
               analytics: {
-                category: 'Qiskit Documentation'
+                category: 'Qiskit.org'
               }
             }
           }

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -42,43 +42,63 @@
   {% endif %}
 
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
-  <!-- <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" /> -->
-  {%- for css in css_files %}
-    {%- if css|attr("rel") %}
-  <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
-    {%- else %}
-  <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
-    {%- endif %}
-  {%- endfor %}
-  {%- for cssfile in extra_css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
-  {%- endfor %}
 
-  {%- block linktags %}
-    {%- if hasdoc('about') %}
-    <link rel="author" title="{{ _('About these documents') }}" href="{{ pathto('about') }}" />
-    {%- endif %}
-    {%- if hasdoc('genindex') %}
-    <link rel="index" title="{{ _('Index') }}" href="{{ pathto('genindex') }}" />
-    {%- endif %}
-    {%- if hasdoc('search') %}
-    <link rel="search" title="{{ _('Search') }}" href="{{ pathto('search') }}" />
-    {%- endif %}
-    {%- if hasdoc('copyright') %}
-    <link rel="copyright" title="{{ _('Copyright') }}" href="{{ pathto('copyright') }}" />
-    {%- endif %}
-    {%- if next %}
-    <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e }}" />
-    {%- endif %}
-    {%- if prev %}
-    <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
-    {%- endif %}
-  {%- endblock %}
-  {%- block extrahead %} {% endblock %}
+  <!-- SEGMENT ANALYTICS -->
+  {% if analytics_enabled %}
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
+        window._analytics = {
+          segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
+          coremetrics: false,
+          optimizely: false,
+          googleAddServices: false,
+          fullStory: false,
+          autoPageEventSpa: false,
+          autoFormEvents: false,
+          autoPageView: false
+        }
 
-  {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
-  <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
+        window.digitalData = {
+          page: {
+            pageInfo: {
+              productTitle: 'IBM Q Experience',
+              analytics: {
+                category: 'Qiskit Documentation'
+              }
+            }
+          }
+        }
 
+        if (!window.bluemixAnalytics || !window.digitalData) { return }
+
+        const category = window.digitalData.page.pageInfo.analytics.category
+        const productTitle = window.digitalData.page.pageInfo.productTitle
+        const routeName = 'documentation'
+
+        window.bluemixAnalytics.pageEvent(category, routeName, {
+          navigationType: 'pushState',
+          productTitle: productTitle,
+          title: document.title
+        })
+
+        window.trackCta = (action) => {
+          if (!window.bluemixAnalytics || !window.digitalData) { return }
+
+          const category = window.digitalData.page.pageInfo.analytics.category
+          const productTitle = window.digitalData.page.pageInfo.productTitle
+
+          window.bluemixAnalytics.trackEvent('CTA Clicked', {
+            productTitle,
+            category,
+            CTA: action
+          })
+        }
+
+      }());
+    </script>
+  {% endif %}
 </head>
 
 <div class="container-fluid header-holder tutorials-header" id="header-holder">

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -10527,8 +10527,8 @@ ul.pytorch-breadcrumbs a {
 .rst-content footer .helpful-container .helpful-question, .rst-content footer .helpful-container .was-helpful-thank-you {
   padding: 0.625rem 1.25rem 0.625rem 1.25rem;
 }
-.rst-content footer .helpful-container .was-helpful-thank-you {
-  display: none;
+#was-helpful-thank-you {
+  visibility: hidden;
 }
 .rst-content footer .helpful-container .helpful-question.yes-link, .rst-content footer .helpful-container .helpful-question.no-link {
   color: #8B34FC;


### PR DESCRIPTION
Included in this PR:

- Added segment analytics to monitor page views
- Added analytics to page feedback buttons (is this helpful? yes/no)
- Made analytics script configurable so users can **_opt in_** to have page views/clicks tracked. Analytics script only run if users set `analytics_enabled: True` in their `conf.py`