### PR TITLE
Change qiskit_x to index in docs_guidelines/index

### DIFF
--- a/docs_guidelines/index.rst
+++ b/docs_guidelines/index.rst
@@ -20,7 +20,7 @@ This site hosts the guidelines and examples for writing and building documentati
    Getting Started <getting_started>
    Tutorials <tutorials/index>
    How-to Guides <how_to/index>
-   API Reference <apidocs/qiskit_x>
+   API Reference <apidocs/index>
    Explanations <explanations/index>
    Release Notes <release_notes>
    GitHub <https://github.com/Qiskit/qiskit_sphinx_theme>


### PR DESCRIPTION
This PR changes `docs_guidelines/index.rst` to reflect the change of `apidocs/qiskit_x` to `apidocs/index`.