### PR TITLE
Remove unnecessary jinja variables

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include qiskit_sphinx_theme/theme.conf
-include qiskit_sphinx_theme/theme_variables.jinja
 include qiskit_sphinx_theme/*.html
 include qiskit_sphinx_theme/static/css/*.css
 include qiskit_sphinx_theme/static/js/*.js

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -1,4 +1,3 @@
-{% import 'theme_variables.jinja' as theme_variables %}
 <!DOCTYPE html>
   <html class="no-js" lang="{{ lang_attr }}" >
 <head>

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'static/css/*.css',
         'static/js/*.js',
         'static/images/*.*',
-        'theme_variables.jinja'
     ]},
     entry_points = {
         'sphinx.html_themes': [


### PR DESCRIPTION
jinja variables are not needed now that we are using a unified top menu, so this PR removes it from the build