### PR TITLE
Fix analytics bug

### DIFF
--- a/qiskit_sphinx_theme/footer.html
+++ b/qiskit_sphinx_theme/footer.html
@@ -36,7 +36,7 @@
   {%- if show_sphinx %}
     {% trans %}
       <div>
-        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using <a href="https://github.com/Qiskit/qiskit_sphinx_theme">Qiskit Sphinx Theme </a> (based on <a href="https://github.com/pytorch/pytorch_sphinx_theme"> PyTorch Sphinx Theme</a>.
+        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using <a href="https://github.com/Qiskit/qiskit_sphinx_theme">Qiskit Sphinx Theme </a> (based on <a href="https://github.com/pytorch/pytorch_sphinx_theme"> PyTorch Sphinx Theme</a>).
       </div>
     {% endtrans %}
   {%- endif %}

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -28,10 +28,8 @@
 
   <!-- SEGMENT ANALYTICS -->
   {% if analytics_enabled %}
-    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
     <script>
       (function () {
-        'use strict'
         window._analytics = {
           segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
           coremetrics: false,
@@ -53,6 +51,12 @@
             }
           }
         }
+      }());
+    </script>
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
 
         if (!window.bluemixAnalytics || !window.digitalData) { return }
 

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -4,8 +4,18 @@
   {# CSS #}
   <!-- get styles in qiskit_sphinx_theme: -->
   <link rel="stylesheet" href="static/css/theme.css">
-  <!-- Get styles in sphinx build: -->
+  <!-- Get any custom styles in sphinx build: -->
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  {%- for css in css_files %}
+    {%- if css|attr("rel") %}
+  <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
+    {%- else %}
+  <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+    {%- endif %}
+  {%- endfor %}
+  {%- for cssfile in extra_css_files %}
+    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+  {%- endfor %}
 
   <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components@0.10.2/experimental-bundled-ui-shell.js">
   <script type="module" src="https://unpkg.com/@qiskit/web-components@0.10.2/experimental-bundled-ui-shell.js"></script>

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -161,6 +161,13 @@
 
   <script type="text/javascript" src="{{ pathto('_static/js/vendor/anchor.min.js', 1) }}"></script>
 
+  <!-- enable language dropdown menu expand -->
+  <script type="text/javascript">
+    jQuery(function () {
+        SphinxRtdTheme.Navigation.enable({{ 'true' if theme_sticky_navigation|tobool else 'false' }});
+    });
+  </script>
+
   <script type="text/javascript">
     $(document).ready(function() {
       mobileMenu.bind();


### PR DESCRIPTION
segment analytics are not working when deployed to qiskit.org. We think the problem could be that the segment key isn't being loaded until after the bluemix script is run. This PR rearranges the scripts so that the `window._analytics` object is set first