### PR TITLE
Fix search

### DIFF
--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -162,6 +162,8 @@
       </section>
     </div>
   
+{%- block footer %} {% endblock %}
+
   <!-- MOBILE MENU FOR SIDEBAR -->
     <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
https://github.com/Qiskit/qiskit/issues/1636 reported the search is broken using the new 1.10.0 version of the theme. This was casued by #119 where a line necessary for search bar to function was removed by accident. It's unclear why to me why such a line is needed at the moment but adding back this line to `layout.html` fix the search and removing it breaks the search. 
