### PR TITLE
prepare 1.10.1

### DIFF
--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -3,7 +3,7 @@
 """
 from os import path
 
-__version__ = '1.10.0'
+__version__ = '1.10.1'
 __version_full__ = __version__
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
 
 setup(
     name = 'qiskit_sphinx_theme',
-    version = '1.10.0',
+    version = '1.10.1',
     author="Qiskit Development Team",
     author_email="hello@qiskit.org",
     url="https://github.com/Qiskit/qiskit_sphinx_theme",


### PR DESCRIPTION
https://github.com/Qiskit/qiskit_sphinx_theme/pull/119 introduced a regression which broke the searchbox (as reported in https://github.com/Qiskit/qiskit/issues/1636) and it was fixed by https://github.com/Qiskit/qiskit_sphinx_theme/pull/139 . This patch release includes the fix. 