### PR TITLE
Pin tox<4.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get install -y pandoc graphviz
       - name: Install python Deps
         run: |
-          python -m pip install -U tox
+          python -m pip install -U 'tox<4'
           python -m pip install -r requirements-dev.txt
       - name: Build Docs
         run: tox -epy -- -j auto


### PR DESCRIPTION
tox 4.0.0 is causing Sample Docs Build workflow to fail. This PR pins the tox version to <4.0.0 temporarily. See more details in https://github.com/Qiskit/qiskit/pull/1642
