### PR TITLE
Fix method theme

### DIFF
--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -306,7 +306,11 @@ span.sig-paren{
   color: #212529;
 }
 
-article.pytorch-article .function dt > code, article.pytorch-article .attribute dt > code, article.pytorch-article .class .attribute dt > code, article.pytorch-article .class dt > code {
+article.pytorch-article .method dt > code, 
+article.pytorch-article .function dt > code, 
+article.pytorch-article .attribute dt > code, 
+article.pytorch-article .class .attribute dt > code, 
+article.pytorch-article .class dt > code {
   font-weight: 600;
 }
 
@@ -10722,7 +10726,11 @@ article.pytorch-article .section :not(dt) > code .pre {
   outline: 0px;
   padding: 0px;
 }
-article.pytorch-article .function dt, article.pytorch-article .attribute dt, article.pytorch-article .class .attribute dt, article.pytorch-article .class dt {
+article.pytorch-article .method dt,
+article.pytorch-article .function dt, 
+article.pytorch-article .attribute dt, 
+article.pytorch-article .class .attribute dt, 
+article.pytorch-article .class dt {
   position: relative;
   background: #f3f4f7;
   padding: 0.5rem;
@@ -10730,14 +10738,29 @@ article.pytorch-article .function dt, article.pytorch-article .attribute dt, art
   word-wrap: break-word;
   padding-right: 100px;
 }
-article.pytorch-article .function dt em.property, article.pytorch-article .attribute dt em.property, article.pytorch-article .class dt em.property {
+article.pytorch-article .method dt em.property, 
+article.pytorch-article .function dt em.property, 
+article.pytorch-article .attribute dt em.property, 
+article.pytorch-article .class dt em.property {
   font-family: inherit;
 }
-article.pytorch-article .function dt em, article.pytorch-article .attribute dt em, article.pytorch-article .class .attribute dt em, article.pytorch-article .class dt em, article.pytorch-article .function dt .sig-paren, article.pytorch-article .attribute dt .sig-paren, article.pytorch-article .class dt .sig-paren {
+article.pytorch-article .method dt em, 
+article.pytorch-article .function dt em, 
+article.pytorch-article .attribute dt em, 
+article.pytorch-article .class .attribute dt em, 
+article.pytorch-article .class dt em,
+article.pytorch-article .method dt .sig-paren,  
+article.pytorch-article .function dt .sig-paren, 
+article.pytorch-article .attribute dt .sig-paren, 
+article.pytorch-article .class dt .sig-paren {
   font-family: var(--font-family-monospace);
   font-size: 87.5%;
 }
-article.pytorch-article .function dt a, article.pytorch-article .attribute dt a, article.pytorch-article .class .attribute dt a, article.pytorch-article .class dt a {
+article.pytorch-article .method dt a, 
+article.pytorch-article .function dt a, 
+article.pytorch-article .attribute dt a, 
+article.pytorch-article .class .attribute dt a, 
+article.pytorch-article .class dt a {
   position: absolute;
   right: 30px;
   padding-right: 0;
@@ -10745,17 +10768,27 @@ article.pytorch-article .function dt a, article.pytorch-article .attribute dt a,
   -webkit-transform: perspective(1px) translateY(-50%);
           transform: perspective(1px) translateY(-50%);
 }
-article.pytorch-article .function dt:hover .viewcode-link, article.pytorch-article .attribute dt:hover .viewcode-link, article.pytorch-article .class dt:hover .viewcode-link {
+article.pytorch-article .method dt:hover .viewcode-link, 
+article.pytorch-article .function dt:hover .viewcode-link, 
+article.pytorch-article .attribute dt:hover .viewcode-link, 
+article.pytorch-article .class dt:hover .viewcode-link {
   color: var(--purple);
 }
-article.pytorch-article .function .anchorjs-link, article.pytorch-article .attribute .anchorjs-link, article.pytorch-article .class .anchorjs-link {
+article.pytorch-article .method .anchorjs-link, 
+article.pytorch-article .function .anchorjs-link, 
+article.pytorch-article .attribute .anchorjs-link, 
+article.pytorch-article .class .anchorjs-link {
   display: inline;
   position: absolute;
   right: 8px;
   font-size: 1.5625rem !important;
   padding-left: 0;
 }
-article.pytorch-article .function dt > code, article.pytorch-article .attribute dt > code, article.pytorch-article .class .attribute dt > code, article.pytorch-article .class dt > code {
+article.pytorch-article .method dt > code,
+article.pytorch-article .function dt > code, 
+article.pytorch-article .attribute dt > code, 
+article.pytorch-article .class .attribute dt > code, 
+article.pytorch-article .class dt > code {
   color: #262626;
   border-top: solid 2px #f3f4f7;
   background-color: #f3f4f7;
@@ -10842,12 +10875,10 @@ article.pytorch-article .class dl dt em.property {
   left: 0;
   padding-right: 0;
 }
-article.pytorch-article .method dt,
 article.pytorch-article .class .staticmethod dt {
   border-left: 3px solid var(--purple);
   border-top: none;
 }
-article.pytorch-article .method dt,
 article.pytorch-article .class .staticmethod dt {
   padding-left: 0.5rem;
 }

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -307,6 +307,7 @@ span.sig-paren{
 }
 
 article.pytorch-article .method dt > code, 
+article.pytorch-article .staticmethod dt > code, 
 article.pytorch-article .function dt > code, 
 article.pytorch-article .attribute dt > code, 
 article.pytorch-article .class .attribute dt > code, 
@@ -10726,7 +10727,8 @@ article.pytorch-article .section :not(dt) > code .pre {
   outline: 0px;
   padding: 0px;
 }
-article.pytorch-article .method dt,
+article.pytorch-article .method dt, 
+article.pytorch-article .staticmethod dt,
 article.pytorch-article .function dt, 
 article.pytorch-article .attribute dt, 
 article.pytorch-article .class .attribute dt, 
@@ -10739,17 +10741,20 @@ article.pytorch-article .class dt {
   padding-right: 100px;
 }
 article.pytorch-article .method dt em.property, 
+article.pytorch-article .staticmethod dt em.property, 
 article.pytorch-article .function dt em.property, 
 article.pytorch-article .attribute dt em.property, 
 article.pytorch-article .class dt em.property {
   font-family: inherit;
 }
 article.pytorch-article .method dt em, 
+article.pytorch-article .staticmethod dt em,
 article.pytorch-article .function dt em, 
 article.pytorch-article .attribute dt em, 
 article.pytorch-article .class .attribute dt em, 
 article.pytorch-article .class dt em,
-article.pytorch-article .method dt .sig-paren,  
+article.pytorch-article .method dt .sig-paren, 
+article.pytorch-article .staticmethod dt .sig-paren, 
 article.pytorch-article .function dt .sig-paren, 
 article.pytorch-article .attribute dt .sig-paren, 
 article.pytorch-article .class dt .sig-paren {
@@ -10757,6 +10762,7 @@ article.pytorch-article .class dt .sig-paren {
   font-size: 87.5%;
 }
 article.pytorch-article .method dt a, 
+article.pytorch-article .staticmethod dt a, 
 article.pytorch-article .function dt a, 
 article.pytorch-article .attribute dt a, 
 article.pytorch-article .class .attribute dt a, 
@@ -10769,12 +10775,14 @@ article.pytorch-article .class dt a {
           transform: perspective(1px) translateY(-50%);
 }
 article.pytorch-article .method dt:hover .viewcode-link, 
+article.pytorch-article .staticmethod dt:hover .viewcode-link, 
 article.pytorch-article .function dt:hover .viewcode-link, 
 article.pytorch-article .attribute dt:hover .viewcode-link, 
 article.pytorch-article .class dt:hover .viewcode-link {
   color: var(--purple);
 }
 article.pytorch-article .method .anchorjs-link, 
+article.pytorch-article .staticmethod .anchorjs-link, 
 article.pytorch-article .function .anchorjs-link, 
 article.pytorch-article .attribute .anchorjs-link, 
 article.pytorch-article .class .anchorjs-link {
@@ -10784,7 +10792,8 @@ article.pytorch-article .class .anchorjs-link {
   font-size: 1.5625rem !important;
   padding-left: 0;
 }
-article.pytorch-article .method dt > code,
+article.pytorch-article .method dt > code, 
+article.pytorch-article .staticmethod dt > code,
 article.pytorch-article .function dt > code, 
 article.pytorch-article .attribute dt > code, 
 article.pytorch-article .class .attribute dt > code, 
@@ -10797,6 +10806,7 @@ article.pytorch-article .class dt > code {
   box-decoration-break: clone;
 }
 article.pytorch-article .method .viewcode-link, 
+article.pytorch-article .staticmethod .viewcode-link, 
 article.pytorch-article .function .viewcode-link, 
 article.pytorch-article .attribute .viewcode-link, 
 article.pytorch-article .class .viewcode-link {
@@ -10807,13 +10817,15 @@ article.pytorch-article .class .viewcode-link {
   text-transform: uppercase;
 }
 article.pytorch-article .method dd, 
+article.pytorch-article .staticmethod dd, 
 article.pytorch-article .function dd, 
 article.pytorch-article .attribute dd, 
 article.pytorch-article .class .attribute dd, 
 article.pytorch-article .class dd {
   padding-left: 3.0rem;
 }
-article.pytorch-article .method dd p,
+article.pytorch-article .method dd p, 
+article.pytorch-article .staticmethod dd p, 
 article.pytorch-article .function dd p, 
 article.pytorch-article .attribute dd p, 
 article.pytorch-article .class .attribute dd p, 
@@ -10821,6 +10833,7 @@ article.pytorch-article .class dd p {
   color: #262626;
 }
 article.pytorch-article .method table tbody tr th.field-name, 
+article.pytorch-article .staticmethod table tbody tr th.field-name, 
 article.pytorch-article .function table tbody tr th.field-name, 
 article.pytorch-article .attribute table tbody tr th.field-name, 
 article.pytorch-article .class table tbody tr th.field-name {
@@ -10830,13 +10843,15 @@ article.pytorch-article .class table tbody tr th.field-name {
 }
 @media screen and (min-width: 768px) {
   article.pytorch-article .method table tbody tr th.field-name, 
+  article.pytorch-article .staticmethod table tbody tr th.field-name, 
   article.pytorch-article .function table tbody tr th.field-name, 
   article.pytorch-article .attribute table tbody tr th.field-name, 
   article.pytorch-article .class table tbody tr th.field-name {
     width: 15%;
   }
 }
-article.pytorch-article .method table tbody tr td.field-body,
+article.pytorch-article .method table tbody tr td.field-body, 
+article.pytorch-article .staticmethod table tbody tr td.field-body,
 article.pytorch-article .function table tbody tr td.field-body, 
 article.pytorch-article .attribute table tbody tr td.field-body, 
 article.pytorch-article .class table tbody tr td.field-body {
@@ -10846,6 +10861,7 @@ article.pytorch-article .class table tbody tr td.field-body {
 }
 @media screen and (min-width: 768px) {
   article.pytorch-article .method table tbody tr td.field-body, 
+  article.pytorch-article .staticmethod table tbody tr td.field-body, 
   article.pytorch-article .function table tbody tr td.field-body, 
   article.pytorch-article .attribute table tbody tr td.field-body, 
   article.pytorch-article .class table tbody tr td.field-body {
@@ -10853,7 +10869,8 @@ article.pytorch-article .class table tbody tr td.field-body {
   }
 }
 @media screen and (min-width: 1600px) {
-  article.pytorch-article .method table tbody tr td.field-body,
+  article.pytorch-article .method table tbody tr td.field-body, 
+  article.pytorch-article .staticmethod table tbody tr td.field-body,
   article.pytorch-article .function table tbody tr td.field-body, 
   article.pytorch-article .attribute table tbody tr td.field-body, 
   article.pytorch-article .class table tbody tr td.field-body {
@@ -10861,29 +10878,34 @@ article.pytorch-article .class table tbody tr td.field-body {
   }
 }
 article.pytorch-article .method table tbody tr td.field-body p, 
+article.pytorch-article .staticmethod table tbody tr td.field-body p, 
 article.pytorch-article .function table tbody tr td.field-body p, 
 article.pytorch-article .attribute table tbody tr td.field-body p, 
 article.pytorch-article .class table tbody tr td.field-body p {
   padding-left: 0px;
 }
 article.pytorch-article .method table tbody tr td.field-body p:last-of-type, 
+article.pytorch-article .staticmethod table tbody tr td.field-body p:last-of-type, 
 article.pytorch-article .function table tbody tr td.field-body p:last-of-type, 
 article.pytorch-article .attribute table tbody tr td.field-body p:last-of-type, 
 article.pytorch-article .class table tbody tr td.field-body p:last-of-type {
   margin-bottom: 0;
 }
 article.pytorch-article .method table tbody tr td.field-body ol, 
+article.pytorch-article .staticmethod table tbody tr td.field-body ol, 
 article.pytorch-article .function table tbody tr td.field-body ol, 
 article.pytorch-article .attribute table tbody tr td.field-body ol, 
 article.pytorch-article .class table tbody tr td.field-body ol, 
-article.pytorch-article .method table tbody tr td.field-body ul,
+article.pytorch-article .method table tbody tr td.field-body ul, 
+article.pytorch-article .staticmethod table tbody tr td.field-body ul,
 article.pytorch-article .function table tbody tr td.field-body ul, 
 article.pytorch-article .attribute table tbody tr td.field-body ul, 
 article.pytorch-article .class table tbody tr td.field-body ul {
   padding-left: 1rem;
   padding-bottom: 0;
 }
-article.pytorch-article .method table.docutils.field-list,
+article.pytorch-article .method table.docutils.field-list, 
+article.pytorch-article .staticmethod table.docutils.field-list,
 article.pytorch-article .function table.docutils.field-list, 
 article.pytorch-article .attribute table.docutils.field-list, 
 article.pytorch-article .class table.docutils.field-list {
@@ -10916,13 +10938,6 @@ article.pytorch-article .class dl dt em.property {
   position: static;
   left: 0;
   padding-right: 0;
-}
-article.pytorch-article .class .staticmethod dt {
-  border-left: 3px solid var(--purple);
-  border-top: none;
-}
-article.pytorch-article .class .staticmethod dt {
-  padding-left: 0.5rem;
 }
 article.pytorch-article .class .attribute dt {
   border-top: none;

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -10842,12 +10842,12 @@ article.pytorch-article .class dl dt em.property {
   left: 0;
   padding-right: 0;
 }
-article.pytorch-article .class .method dt,
+article.pytorch-article .method dt,
 article.pytorch-article .class .staticmethod dt {
   border-left: 3px solid var(--purple);
   border-top: none;
 }
-article.pytorch-article .class .method dt,
+article.pytorch-article .method dt,
 article.pytorch-article .class .staticmethod dt {
   padding-left: 0.5rem;
 }

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -10796,55 +10796,97 @@ article.pytorch-article .class dt > code {
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
 }
-article.pytorch-article .function .viewcode-link, article.pytorch-article .attribute .viewcode-link, article.pytorch-article .class .viewcode-link {
+article.pytorch-article .method .viewcode-link, 
+article.pytorch-article .function .viewcode-link, 
+article.pytorch-article .attribute .viewcode-link, 
+article.pytorch-article .class .viewcode-link {
   font-size: 0.875rem;
   color: #979797;
   letter-spacing: 0;
   line-height: 1.5rem;
   text-transform: uppercase;
 }
-article.pytorch-article .function dd, article.pytorch-article .attribute dd, article.pytorch-article .class .attribute dd, article.pytorch-article .class dd {
+article.pytorch-article .method dd, 
+article.pytorch-article .function dd, 
+article.pytorch-article .attribute dd, 
+article.pytorch-article .class .attribute dd, 
+article.pytorch-article .class dd {
   padding-left: 3.0rem;
 }
-article.pytorch-article .function dd p, article.pytorch-article .attribute dd p, article.pytorch-article .class .attribute dd p, article.pytorch-article .class dd p {
+article.pytorch-article .method dd p,
+article.pytorch-article .function dd p, 
+article.pytorch-article .attribute dd p, 
+article.pytorch-article .class .attribute dd p, 
+article.pytorch-article .class dd p {
   color: #262626;
 }
-article.pytorch-article .function table tbody tr th.field-name, article.pytorch-article .attribute table tbody tr th.field-name, article.pytorch-article .class table tbody tr th.field-name {
+article.pytorch-article .method table tbody tr th.field-name, 
+article.pytorch-article .function table tbody tr th.field-name, 
+article.pytorch-article .attribute table tbody tr th.field-name, 
+article.pytorch-article .class table tbody tr th.field-name {
   white-space: nowrap;
   color: #262626;
   width: 20%;
 }
 @media screen and (min-width: 768px) {
-  article.pytorch-article .function table tbody tr th.field-name, article.pytorch-article .attribute table tbody tr th.field-name, article.pytorch-article .class table tbody tr th.field-name {
+  article.pytorch-article .method table tbody tr th.field-name, 
+  article.pytorch-article .function table tbody tr th.field-name, 
+  article.pytorch-article .attribute table tbody tr th.field-name, 
+  article.pytorch-article .class table tbody tr th.field-name {
     width: 15%;
   }
 }
-article.pytorch-article .function table tbody tr td.field-body, article.pytorch-article .attribute table tbody tr td.field-body, article.pytorch-article .class table tbody tr td.field-body {
+article.pytorch-article .method table tbody tr td.field-body,
+article.pytorch-article .function table tbody tr td.field-body, 
+article.pytorch-article .attribute table tbody tr td.field-body, 
+article.pytorch-article .class table tbody tr td.field-body {
   padding: 0.625rem;
   width: 80%;
   color: #262626;
 }
 @media screen and (min-width: 768px) {
-  article.pytorch-article .function table tbody tr td.field-body, article.pytorch-article .attribute table tbody tr td.field-body, article.pytorch-article .class table tbody tr td.field-body {
+  article.pytorch-article .method table tbody tr td.field-body, 
+  article.pytorch-article .function table tbody tr td.field-body, 
+  article.pytorch-article .attribute table tbody tr td.field-body, 
+  article.pytorch-article .class table tbody tr td.field-body {
     width: 85%;
   }
 }
 @media screen and (min-width: 1600px) {
-  article.pytorch-article .function table tbody tr td.field-body, article.pytorch-article .attribute table tbody tr td.field-body, article.pytorch-article .class table tbody tr td.field-body {
+  article.pytorch-article .method table tbody tr td.field-body,
+  article.pytorch-article .function table tbody tr td.field-body, 
+  article.pytorch-article .attribute table tbody tr td.field-body, 
+  article.pytorch-article .class table tbody tr td.field-body {
     padding-left: 1.25rem;
   }
 }
-article.pytorch-article .function table tbody tr td.field-body p, article.pytorch-article .attribute table tbody tr td.field-body p, article.pytorch-article .class table tbody tr td.field-body p {
+article.pytorch-article .method table tbody tr td.field-body p, 
+article.pytorch-article .function table tbody tr td.field-body p, 
+article.pytorch-article .attribute table tbody tr td.field-body p, 
+article.pytorch-article .class table tbody tr td.field-body p {
   padding-left: 0px;
 }
-article.pytorch-article .function table tbody tr td.field-body p:last-of-type, article.pytorch-article .attribute table tbody tr td.field-body p:last-of-type, article.pytorch-article .class table tbody tr td.field-body p:last-of-type {
+article.pytorch-article .method table tbody tr td.field-body p:last-of-type, 
+article.pytorch-article .function table tbody tr td.field-body p:last-of-type, 
+article.pytorch-article .attribute table tbody tr td.field-body p:last-of-type, 
+article.pytorch-article .class table tbody tr td.field-body p:last-of-type {
   margin-bottom: 0;
 }
-article.pytorch-article .function table tbody tr td.field-body ol, article.pytorch-article .attribute table tbody tr td.field-body ol, article.pytorch-article .class table tbody tr td.field-body ol, article.pytorch-article .function table tbody tr td.field-body ul, article.pytorch-article .attribute table tbody tr td.field-body ul, article.pytorch-article .class table tbody tr td.field-body ul {
+article.pytorch-article .method table tbody tr td.field-body ol, 
+article.pytorch-article .function table tbody tr td.field-body ol, 
+article.pytorch-article .attribute table tbody tr td.field-body ol, 
+article.pytorch-article .class table tbody tr td.field-body ol, 
+article.pytorch-article .method table tbody tr td.field-body ul,
+article.pytorch-article .function table tbody tr td.field-body ul, 
+article.pytorch-article .attribute table tbody tr td.field-body ul, 
+article.pytorch-article .class table tbody tr td.field-body ul {
   padding-left: 1rem;
   padding-bottom: 0;
 }
-article.pytorch-article .function table.docutils.field-list, article.pytorch-article .attribute table.docutils.field-list, article.pytorch-article .class table.docutils.field-list {
+article.pytorch-article .method table.docutils.field-list,
+article.pytorch-article .function table.docutils.field-list, 
+article.pytorch-article .attribute table.docutils.field-list, 
+article.pytorch-article .class table.docutils.field-list {
   margin-bottom: 0.75rem;
 }
 article.pytorch-article .attribute .has-code {


### PR DESCRIPTION
Fixes #45 

This PR fixes the `methods` level rendering to match `functions` style.
- ~~CSS selector was not picking up correct element with targeted method class.~~ (this was one problem but it did not fully match `functions` theme style)
- Adjusts all elements style under `method` and `static method` html class to be consistent with `functions` styling theme
![image](https://user-images.githubusercontent.com/25207344/207920221-b19a16ed-358d-4669-8d8c-bd72b4af1b0f.png)
Compared to functions theme rendering:
![image](https://user-images.githubusercontent.com/25207344/207920313-100ec90c-16e4-4db7-a7ed-512d03e57b41.png)

Follow up on separate PR:
- Add a `methods.rst` example under `docs/sphinx-guide/`