### PR TITLE
Adjust sidebar code to not include "hidden" toctree items

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,59 @@ By enabling analytics we will be able to collect information on number of visits
 <img width="538" alt="Screenshot 2022-11-14 at 11 28 11 AM" src="https://user-images.githubusercontent.com/23662430/201715694-1e75b1fb-875b-4137-b9f3-93d1e1894f5a.png">
 
 If you do not enable analytics no data will be collected and the `Was this page helpful?` component will not show.
+
+## Toctree visibility
+
+When creating a toctree in Sphinx, it is possible to add a `:hidden:` directive to hide those headings from the page. When using this theme any toctrees using the `:hidden:` directive will NOT show those headings either in the centre page toctree list OR in the sidebar. Toctrees without the `:hidden:` directive will be displayed in the sidebar but will NOT be displayed in the centre page toctree list. 
+
+For example, see below an `index.rst` with different toctree types and corresponding layout using the theme:
+
+```
+###########################################
+Qiskit sphinx theme |version| documentation
+###########################################
+
+
+
+.. toctree::
+  :maxdepth: 1
+  :caption: Basic functionality
+
+   Structural formatting <sphinx_guide/structural>
+   Paragraph-level markup <sphinx_guide/paragraph>
+   Lists and tables <sphinx_guide/lists_tables>
+   Functions <sphinx_guide/functions>
+   Classes <sphinx_guide/classes>
+   Images <sphinx_guide/images>
+   Jupyter <sphinx_guide/jupyter>
+   Panels <sphinx_guide/panels>
+
+   .. these headings are included in the toc tree but hidden from the sidebar:
+.. toctree::
+  :maxdepth: 1
+  :hidden:
+
+   hiddenTitle1 <sphinx_guide/structural>
+   hiddenTitle2 <sphinx_guide/paragraph>
+   hiddenTitle3 <sphinx_guide/lists_tables>
+
+
+.. Hiding - Indices and tables
+   :ref:`genindex`
+   :ref:`modindex`
+   :ref:`search`
+```
+
+<img width="1135" alt="Screenshot 2023-01-17 at 11 26 53 AM" src="https://user-images.githubusercontent.com/23662430/212863759-96a753cf-8c44-493b-a519-8022887b609d.png">
+
+If you want the toctree list displayed in the centre page section as well as the sidebar you can do so by adding a `custom.css` file in your `docs/_static` directory, then adding the following custom CSS to that file:
+
+```
+.toctree-wrapper.compound {
+  display: unset;
+}
+```
+
+Using the `index.rst` example from earlier, adding this custom CSS this will show the following:
+
+<img width="1133" alt="Screenshot 2023-01-17 at 11 26 00 AM" src="https://user-images.githubusercontent.com/23662430/212864931-1bbb4aec-5923-4eb4-9d50-36a55150e9e7.png">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Qiskit sphinx theme |version| documentation
 
 .. toctree::
   :maxdepth: 1
-    :caption: Basic functionality
+  :caption: Basic functionality
 
    Structural formatting <sphinx_guide/structural>
    Paragraph-level markup <sphinx_guide/paragraph>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Qiskit sphinx theme |version| documentation
    Jupyter <sphinx_guide/jupyter>
    Panels <sphinx_guide/panels>
 
-  ..  
+  ..
     these headings are included in the toc tree but hidden from the sidebar
 .. toctree::
   :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,6 @@ Qiskit sphinx theme |version| documentation
    Jupyter <sphinx_guide/jupyter>
    Panels <sphinx_guide/panels>
 
-  ..
-    these headings are included in the toc tree but hidden from the sidebar
 .. toctree::
   :maxdepth: 1
   :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,8 @@ Qiskit sphinx theme |version| documentation
    Jupyter <sphinx_guide/jupyter>
    Panels <sphinx_guide/panels>
 
-   .. these headings are included in the toc tree but hidden from the sidebar
+  ..  
+    these headings are included in the toc tree but hidden from the sidebar
 .. toctree::
   :maxdepth: 1
   :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,7 @@ Qiskit sphinx theme |version| documentation
 
 .. toctree::
   :maxdepth: 1
-  :caption: Basic functionality
-  :hidden:
+    :caption: Basic functionality
 
    Structural formatting <sphinx_guide/structural>
    Paragraph-level markup <sphinx_guide/paragraph>
@@ -17,6 +16,15 @@ Qiskit sphinx theme |version| documentation
    Images <sphinx_guide/images>
    Jupyter <sphinx_guide/jupyter>
    Panels <sphinx_guide/panels>
+
+   .. these headings are included in the toc tree but hidden from the sidebar
+.. toctree::
+  :maxdepth: 1
+  :hidden:
+
+   hidden <sphinx_guide/structural>
+   hidden <sphinx_guide/paragraph>
+   hidden <sphinx_guide/lists_tables>
 
 
 .. Hiding - Indices and tables

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -115,7 +115,7 @@
           <!-- render sidebar from the toctree -->
           {% set global_toc = toctree(maxdepth=1,
             collapse=theme_collapse_navigation|tobool,
-            includehidden=theme_includehidden|tobool) %}
+            includehidden=False) %}
           {% if global_toc %}
             {{ global_toc }}
           {% endif %}

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -28,10 +28,8 @@
 
   <!-- SEGMENT ANALYTICS -->
   {% if analytics_enabled %}
-    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
     <script>
       (function () {
-        'use strict'
         window._analytics = {
           segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
           coremetrics: false,
@@ -53,6 +51,12 @@
             }
           }
         }
+      }());
+    </script>
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
 
         if (!window.bluemixAnalytics || !window.digitalData) { return }
 

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -36,6 +36,10 @@
   --font-family-monospace: "IBM PLex Mono", Consolas, "Courier New", monospace;
 }
 
+.toctree-wrapper.compound {
+  display: none;
+}
+
 /* Old theme variables */
 
 .wy-table-responsive {


### PR DESCRIPTION
based on the discussion [here](https://github.com/Qiskit/qiskit/pull/1638), sometimes index files might need to add items to the toctree that shouldn't be added to the sidebar. This PR adjusts the sidebar code to not include toctree items that have a "hidden" flag on their directive

E.g. `index.rst` has some "hidden" toc items that are not displayed by the sidebar
<img width="402" alt="Screenshot 2023-01-10 at 7 27 03 PM" src="https://user-images.githubusercontent.com/23662430/211620774-208e5903-3f91-4fd6-9972-0620aa1663d0.png">
<img width="412" alt="Screenshot 2023-01-10 at 7 27 16 PM" src="https://user-images.githubusercontent.com/23662430/211620753-c94f96de-3b1b-4cb2-8352-de41623ab2a8.png">
