### PR TITLE
Remove version number from top menu component

### DIFF
--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -17,8 +17,8 @@
     <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
   {%- endfor %}
 
-  <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components@0.10.2/experimental-bundled-ui-shell.js">
-  <script type="module" src="https://unpkg.com/@qiskit/web-components@0.10.2/experimental-bundled-ui-shell.js"></script>
+  <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components@0.11.1/experimental-bundled-ui-shell.js">
+  <script type="module" src="https://unpkg.com/@qiskit/web-components@0.11.1/experimental-bundled-ui-shell.js"></script>
   <style>
     qiskit-ui-shell:not(:defined) {
       display: block;

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -28,10 +28,8 @@
 
   <!-- SEGMENT ANALYTICS -->
   {% if analytics_enabled %}
-    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
     <script>
       (function () {
-        'use strict'
         window._analytics = {
           segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
           coremetrics: false,
@@ -53,6 +51,12 @@
             }
           }
         }
+      }());
+    </script>
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
 
         if (!window.bluemixAnalytics || !window.digitalData) { return }
 

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -17,8 +17,8 @@
     <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
   {%- endfor %}
 
-  <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components@0.11.1/experimental-bundled-ui-shell.js">
-  <script type="module" src="https://unpkg.com/@qiskit/web-components@0.11.1/experimental-bundled-ui-shell.js"></script>
+  <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components/experimental-bundled-ui-shell.js">
+  <script type="module" src="https://unpkg.com/@qiskit/web-components/experimental-bundled-ui-shell.js"></script>
   <style>
     qiskit-ui-shell:not(:defined) {
       display: block;


### PR DESCRIPTION
If we remove the version number from the CDN url then we can automatically pull the latest version of the unified top menu without needing to put out new releases of the theme