### PR TITLE
Fix automatic scrolling bug

### DIFF
--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -28,10 +28,8 @@
 
   <!-- SEGMENT ANALYTICS -->
   {% if analytics_enabled %}
-    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
     <script>
       (function () {
-        'use strict'
         window._analytics = {
           segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
           coremetrics: false,
@@ -53,6 +51,12 @@
             }
           }
         }
+      }());
+    </script>
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
 
         if (!window.bluemixAnalytics || !window.digitalData) { return }
 

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -34,6 +34,11 @@
   --breakpoint-xl: 1200px;
   --font-family-sans-serif: "IBM PLex Sans", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-family-monospace: "IBM PLex Mono", Consolas, "Courier New", monospace;
+  --header-height: 52px;
+}
+
+section {
+  scroll-margin-top: var(--header-height);
 }
 
 /* Old theme variables */


### PR DESCRIPTION
For some pages in the documentation if you scroll down a page and then click a link to another page, the new page loads already scrolled down to the same scroll position as on the last page, instead of setting the scroll position to the top of the page. This bug only seems to appear in examples already in production, I haven't been able to replicate it with our local docs build. This PR implements the fix suggested in the original issue, but we may only be able to validate this fix works during once we release the next rc1.

fixes #163 