### PR TITLE
Add back next and previous buttons to footer

### DIFF
--- a/qiskit_sphinx_theme/footer.html
+++ b/qiskit_sphinx_theme/footer.html
@@ -13,6 +13,16 @@
   
   {% endif %}
 
+  <!-- NEXT/PREVIOUS BUTTONS -->
+  <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+    {% if next %}
+      <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="next-page"></a>
+    {% endif %}
+    {% if prev %}
+      <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="previous-page"> {{ _('Previous') }}</a>
+    {% endif %}
+  </div>
+
   <div role="contentinfo">
     <p>
     <!-- SHOW QISKIT COPYRIGHT TEXT -->
@@ -42,7 +52,7 @@
   {%- endif %}
 
   {%- block extrafooter %} {% endblock %}
-
+<br>
 </footer>
 
 <script>

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -28,10 +28,8 @@
 
   <!-- SEGMENT ANALYTICS -->
   {% if analytics_enabled %}
-    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
     <script>
       (function () {
-        'use strict'
         window._analytics = {
           segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
           coremetrics: false,
@@ -53,6 +51,12 @@
             }
           }
         }
+      }());
+    </script>
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
 
         if (!window.bluemixAnalytics || !window.digitalData) { return }
 


### PR DESCRIPTION
In an earlier version of the theme we removed the "Next" and "Previous" buttons in the footer. In response to user requests and further discussion we have decided to add that component back.

fixes #174 

In this PR:
- added back the original code for the next/previous buttons
- added a small line break at the very end of the footer so that the copyright text doesn't sit so close to the edge of the page.

<img width="966" alt="Screenshot 2023-02-09 at 2 52 40 PM" src="https://user-images.githubusercontent.com/23662430/217818918-e73433a6-4c44-490e-ad57-f6ded270f46d.png">
