### PR TITLE
Add missing steps to "run locally" instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ This subfolder contains some example `.rst` files that show how to implement spe
 ------
 ## Run locally
 
-1. Set up a python environment to work in.
-2. Run `pip install .` (must do this every time).
-3. Run `sphinx-build -b html docs/ docs/_build/html` to build the documentation. This will create the `/docs/_build` subfolder where you can see the html files generated based on the `.rst` files in the `docs` folder and the styles pulled from the `qiskit_sphinx_theme`.
+1. Set up a Python environment to work in, e.g.:
+   1. `python3 -m venv .venv/`
+   2. `source .venv/bin/activate`
+2. Run `pip install -r requirements-dev.txt`
+3. Run `pip install .` (must do this every time there is a change to the theme).
+4. Run `sphinx-build -b html docs/ docs/_build/html` to build the documentation. This will create the `/docs/_build` subfolder where you can see the html files generated based on the `.rst` files in the `docs` folder and the styles pulled from the `qiskit_sphinx_theme`.


### PR DESCRIPTION
`pip install -r requirements-dev.txt` was missing, which will cause errors in a new repo.