### PR TITLE
Tidied up breadcrumbs file

### DIFF
--- a/qiskit_sphinx_theme/breadcrumbs.html
+++ b/qiskit_sphinx_theme/breadcrumbs.html
@@ -1,40 +1,10 @@
-{# Support for Sphinx 1.3+ page_source_suffix, but don't break old builds. #}
-
-{% if page_source_suffix %}
-{% set suffix = page_source_suffix %}
-{% else %}
-{% set suffix = source_suffix %}
-{% endif %}
-
-{% if meta is defined and meta is not none %}
-{% set check_meta = True %}
-{% else %}
-{% set check_meta = False %}
-{% endif %}
-
-{% if check_meta and 'github_url' in meta %}
-{% set display_github = True %}
-{% endif %}
-
-{% if check_meta and 'bitbucket_url' in meta %}
-{% set display_bitbucket = True %}
-{% endif %}
-
-{% if check_meta and 'gitlab_url' in meta %}
-{% set display_gitlab = True %}
-{% endif %}
-
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="pytorch-breadcrumbs">
     {% block breadcrumbs %}
       <li>
         <a href="{{ pathto(master_doc) }}">
-          {% if theme_pytorch_project == 'tutorials' %}
-            Tutorials
-          {% else %}
             {{ project }} documentation
-          {% endif %}
         </a> &gt;
       </li>
 
@@ -43,48 +13,5 @@
         {% endfor %}
       <li>{{ title }}</li>
     {% endblock %}
-    {% block breadcrumbs_aside %}
-      <li class="pytorch-breadcrumbs-aside">
-        {% if hasdoc(pagename) %}
-            {% if display_github %}
-            {% if check_meta and 'github_url' in meta %}
-              <!-- User defined GitHub URL -->
-              <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
-            {% else %}
-              <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
-            {% endif %}
-          {% elif display_bitbucket %}
-            {% if check_meta and 'bitbucket_url' in meta %}
-              <!-- User defined Bitbucket URL -->
-              <a href="{{ meta['bitbucket_url'] }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
-            {% else %}
-              <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}?mode={{ theme_vcs_pageview_mode|default("view") }}" class="fa fa-bitbucket"> {{ _('Edit on Bitbucket') }}</a>
-            {% endif %}
-          {% elif display_gitlab %}
-            {% if check_meta and 'gitlab_url' in meta %}
-              <!-- User defined GitLab URL -->
-              <a href="{{ meta['gitlab_url'] }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
-            {% else %}
-              <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
-            {% endif %}
-          {% elif show_source and source_url_prefix %}
-            <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}"><img src="{{ pathto('_static/images/view-page-source-icon.svg', 1) }}"></a>
-          {% elif show_source and has_source and sourcename %}
-            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"><img src="{{ pathto('_static/images/view-page-source-icon.svg', 1) }}"></a>
-          {% endif %}
-        {% endif %}
-      </li>
-    {% endblock %}
   </ul>
-
-  {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-  <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="breadcrumb navigation">
-      {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n">Next <span class="fa fa-arrow-circle-right"></span></a>
-      {% endif %}
-      {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p"><span class="fa fa-arrow-circle-left"></span> Previous</a>
-      {% endif %}
-  </div>
-  {% endif %}
 </div>

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -28,10 +28,8 @@
 
   <!-- SEGMENT ANALYTICS -->
   {% if analytics_enabled %}
-    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
     <script>
       (function () {
-        'use strict'
         window._analytics = {
           segment_key: 'ffdYLviQze3kzomaINXNk6NwpY9LlXcw',
           coremetrics: false,
@@ -53,6 +51,12 @@
             }
           }
         }
+      }());
+    </script>
+    <script src="https://cloud.ibm.com/analytics/build/bluemix-analytics.min.js"></script>
+    <script>
+      (function () {
+        'use strict'
 
         if (!window.bluemixAnalytics || !window.digitalData) { return }
 

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -12372,6 +12372,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   border-bottom: 1px solid #e2e2e2;
   width: 100%;
   z-index: 201;
+  height: fit-content;
 }
 @media screen and (min-width: 1101px) {
   .pytorch-page-level-bar {
@@ -12382,6 +12383,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     height: 45px;
     padding-left: 0;
     width: 100%;
+    height: fit-content;
     position: absolute;
     z-index: 1;
   }
@@ -12390,6 +12392,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     top: 0;
     left: 25%;
     padding-left: 0;
+    height: fit-content;
     right: 0;
     width: 75%;
   }
@@ -12399,12 +12402,14 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     left: 0;
     right: 0;
     width: auto;
+    height: fit-content;
     z-index: 1;
   }
   .pytorch-page-level-bar.left-menu-is-fixed {
     left: 350px;
     right: 0;
     width: auto;
+    height: fit-content;
   }
 }
 .pytorch-page-level-bar ul, .pytorch-page-level-bar li {


### PR DESCRIPTION
fixes #114 

In this PR:
- After discussion in one of our meetings we decided to remove the code button from the breadcrumbs (which is why most of the jinja logic in the file is now gone). This decision was made because qiskit projects already provide a link to the source code from the individual class/functions so it wasn't adding much value. There is an issue open (#186 ) for further work on improving the source code links
- adjusted the CSS styling of the breadcrumbs box so the long text (3 lines or more) doesn't overflow the breadcrumbs box

before:
<img width="941" alt="Screenshot 2023-02-23 at 4 18 32 PM" src="https://user-images.githubusercontent.com/23662430/221032475-66e71657-df37-40f0-8b40-4554d0cee7fd.png">


after:
<img width="962" alt="Screenshot 2023-02-23 at 3 58 40 PM" src="https://user-images.githubusercontent.com/23662430/221032078-b2a8d94b-c00b-4b24-8be4-c85e2008ea49.png">
