### PR TITLE
Display full texts on right summary menu

### DIFF
--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -12138,7 +12138,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 .pytorch-right-menu a:hover span.pre {
   color: #6c6c6d;
 }
-#pytorch-right-menu a.reference.internal{
+.pytorch-right-menu a.reference.internal{
   word-wrap: break-word;
   width: 75%;
   display: block;

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -12138,6 +12138,11 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 .pytorch-right-menu a:hover span.pre {
   color: #6c6c6d;
 }
+#pytorch-right-menu a.reference.internal{
+  word-wrap: break-word;
+  width: 75%;
+  display: block;
+}
 .pytorch-right-menu a.reference.internal.expanded:before {
   content: "-";
   font-family: var(--font-family-monospace);


### PR DESCRIPTION
Fixes #195

![image](https://user-images.githubusercontent.com/25207344/222500660-14bdac9b-7436-444e-958b-0cb81be6026a.png)

Before:
<img src="https://user-images.githubusercontent.com/25207344/222501802-bc3703a7-3a9f-4c22-869e-0e923da08fee.png" width="350">

