### PR TITLE
Fix HTML meta-tag output

### DIFF
--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -1,11 +1,25 @@
+{# Sphinx template variable setup #}
+{%- if not embedded and docstitle %}
+  {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
+{%- else %}
+  {%- set titlesuffix = "" %}
+{%- endif %}
+{%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) -%}
+
 <!DOCTYPE html>
   <html class="no-js" lang="{{ lang_attr }}" >
 <head>
-  {# CSS #}
-  <!-- get styles in qiskit_sphinx_theme: -->
-  <link rel="stylesheet" href="static/css/theme.css">
-  <!-- Get any custom styles in sphinx build: -->
-  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+  <meta charset="{{ encoding }}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {{ metatags }}
+  {%- block htmltitle %}
+  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+  {%- endblock %}
+  {%- if favicon_url %}
+  <link rel="shortcut icon" href="{{ favicon_url }}" />
+  {%- endif %}
+
+  {#- CSS #}
   {%- for css in css_files %}
     {%- if css|attr("rel") %}
   <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
@@ -14,8 +28,8 @@
     {%- endif %}
   {%- endfor %}
   {%- for cssfile in extra_css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
-  {%- endfor %}
+  <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+  {%- endfor -%}
 
   <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components/experimental-bundled-ui-shell.js">
   <script type="module" src="https://unpkg.com/@qiskit/web-components/experimental-bundled-ui-shell.js"></script>
@@ -27,7 +41,7 @@
   </style>
 
   <!-- SEGMENT ANALYTICS -->
-  {% if analytics_enabled %}
+  {%- if analytics_enabled %}
     <script>
       (function () {
         window._analytics = {
@@ -85,7 +99,7 @@
 
       }());
     </script>
-  {% endif %}
+  {%- endif -%}
 
 </head>
 <body class="pytorch-body">


### PR DESCRIPTION
Commit 6538ba1 (gh-119) removed several bits of HTML meta information from the Jinja template of the layout.  This caused (amongst other things):

* the HTML "title" elements to not be output, which means that things like search engines couldn't display nice output and tab titles were missing information

* the `<meta charset="utf-8">` (or appropriate charset) to be omitted. Some OSes and browser combinations would then default to `latin-1` (or other) and not utf-8 for some pages, making several text-output circuit drawings illegible.

This commit restores the meta-tag information to the relevant Jinja template, and tidies up some duplicate outputs.

---

As a side note: there doesn't appear to be a favicon defined anywhere, though Sphinx officially supports one.  I suspect that this happens to work for our deployed documentation because there's one at https://qiskit.org/favicon.ico and historically web browsers have always just sent an exploratory request there to see.  The favicon being absent is why local builds don't get one, though.