### PR TITLE
Improve Tox setup in CI

### DIFF
--- a/.github/workflows/docs-guide-deploy.yml
+++ b/.github/workflows/docs-guide-deploy.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Install tox
         run: python -m pip install -U 'tox<4'
       - name: Test Code Examples
-        run: tox -edoctest -- -j auto
+        run: tox -e doctest
       - name: Build Docs Guide
-        run: tox -edocs-guide -- -j auto
+        run: tox -e docs-guide
       - name: Bypass Jekyll Processing # Necessary for setting the correct css path
         run: touch docs_guide/_build/html/.nojekyll
       - name: Deploy

--- a/.github/workflows/docs-guide-test.yml
+++ b/.github/workflows/docs-guide-test.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Install tox
         run: python -m pip install -U 'tox<4'
       - name: Test Code Examples
-        run: tox -edoctest -- -j auto
+        run: tox -e doctest
       - name: Build Docs Guide
-        run: tox -edocs-guide -- -j auto
+        run: tox -e docs-guide
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,11 @@ jobs:
           python-version: 3.7
       - name: Install ubuntu Deps
         run: sudo apt-get install -y pandoc graphviz
-      - name: Install python Deps
+      - name: Install tox
         run: |
           python -m pip install -U 'tox<4'
-          python -m pip install -r requirements-dev.txt
       - name: Build Docs
-        run: tox -epy -- -j auto
+        run: tox -e py
       - name: Compress Artifacts
         run: |
           mkdir artifacts

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 2.1
+minversion = 3.10
 envlist = py310,py39,py38,py37,lint
 skipsdist = True
 
@@ -8,7 +8,7 @@ usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps =
   -r{toxinidir}/requirements-dev.txt
-commands = sphinx-build -b html -W {posargs} docs/ docs/_build/html
+commands = sphinx-build -b html -W --keep-going -j auto {posargs} docs/ docs/_build/html
 
 [testenv:docs-guide]
 usedevelop = True
@@ -16,7 +16,7 @@ install_command = pip install -U {opts} {packages}
 deps =
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/docs_guide/requirements-extra.txt
-commands = sphinx-build -b html -W {posargs} docs_guide/ docs_guide/_build/html
+commands = sphinx-build -b html -W --keep-going -j auto {posargs} docs_guide/ docs_guide/_build/html
 
 [testenv:doctest]
 usedevelop = True
@@ -24,12 +24,9 @@ install_command = pip install -U {opts} {packages}
 deps =
   -r{toxinidir}/requirements-dev.txt
   -r{toxinidir}/docs_guide/requirements-extra.txt
-commands = sphinx-build -b doctest {posargs} docs_guide/ docs_guide/_build/doctest
+commands = sphinx-build -b doctest -W --keep-going -j auto {posargs} docs_guide/ docs_guide/_build/doctest
 
 [testenv:lint]
 envdir = .tox/lint
 commands =
   pylint -rn -j 0 --rcfile={toxinidir}/.pylintrc qiskit_sphinx_theme
-
-[pycodestyle]
-max-line-length = 100


### PR DESCRIPTION
A couple improvements:

1. Always run Tox with `-j auto`. This is useful on local machines too for better parallelism.
2. Add `--keep-going` so that we don't error on the first warning.
3. Don't `pip install -r requirements-dev.txt` in CI. It's not necessary and slows down CI.
4. Remove unused `pycodestyle` snippet from `tox.ini`.