### PR TITLE
Restore original paragraph spacing

### DIFF
--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -10348,7 +10348,13 @@ article.pytorch-article p,
 article.pytorch-article ul li,
 article.pytorch-article ol li,
 article.pytorch-article dl dt,
-article.pytorch-article dl dd,
+article.pytorch-article dl dd {
+  font-size: 1rem;
+  line-height: 1.375rem;
+  color: #262626;
+  letter-spacing: 0.01px;
+  font-weight: 400;
+}
 
 article.pytorch-article table {
   margin-bottom: 2.5rem;

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -10347,7 +10347,6 @@ article.pytorch-article p {
 article.pytorch-article p,
 article.pytorch-article ul li,
 article.pytorch-article ol li,
-article.pytorch-article dl dt,
 article.pytorch-article dl dd {
   font-size: 1rem;
   line-height: 1.375rem;


### PR DESCRIPTION
https://github.com/Qiskit/qiskit_sphinx_theme/pull/103 removed a couple CSS rules that were being applied to blockquote, which was intentional. 

But in the process, it resulted in `p` and some elements like `ul li` losing those rules too, and using the `table` rule from below. I suspect this was unintentional because there was a blank line between those elements and the table element:

```css
article.pytorch-article dl dt,
article.pytorch-article dl dd

article.pytorch-article table {
   ..
}
```

This change resulted in paragraphs having a bottom margin of `2.5rem`, when we want the theme's default of `1.125rem`.

--

This doesn't seem to impact spacing in `<ol>` and `<ul>`, but the code before this PR did cause too much space in `<dl>` (description list). Meanwhile, the code before https://github.com/Qiskit/qiskit_sphinx_theme/pull/103 was bad that it was setting the style for `<dt>` (term), which resulted in the font not being bolded until https://github.com/Qiskit/qiskit_sphinx_theme/pull/103. So, this PR fixes the spacing, but removes `dt` from the rule set so that it stays bold. 

## Before

![Screenshot 2023-03-13 at 8 27 54 AM](https://user-images.githubusercontent.com/14852634/224731231-12c71acd-ca84-403e-81f3-2d228354d9a1.png)

--

![Screenshot 2023-03-13 at 8 35 53 AM](https://user-images.githubusercontent.com/14852634/224733534-4c7d84c0-5eae-4270-863f-e3a50f99a2c3.png)

## After

![Screenshot 2023-03-13 at 8 26 02 AM](https://user-images.githubusercontent.com/14852634/224730644-5ced1673-84b1-48e9-9812-fa4d9851265c.png)

--

![Screenshot 2023-03-13 at 8 39 26 AM](https://user-images.githubusercontent.com/14852634/224734468-c2f46247-b0f6-40e5-9abc-b95758c6cdef.png)
