### PR TITLE
Deprecate `get_html_theme_path()`

### DIFF
--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -16,7 +16,7 @@ def get_html_theme_path():
     """
     warn(
         "`qiskit_sphinx_theme.get_html_theme_path()` is deprecated and will be removed in version "
-        "1.12 of the package. We are adding multiple 'variants' / theme names to the package, so "
+        "1.13 of the package. We are adding multiple 'variants' / theme names to the package, so "
         "the function no longer makes semantic sense.\n\n"
         "It should not be necessary to set the option `html_theme_path`; you only need to set "
         "`html_theme`. See https://github.com/Qiskit/qiskit-finance/pull/244 for an example.",

--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -2,17 +2,32 @@
 
 """
 from os import path
+from warnings import warn
 
 __version__ = '1.11.0rc1'
 __version_full__ = __version__
 
 
 def get_html_theme_path():
-    """Return list of HTML theme paths."""
+    """Return the absolute path to this package.
+
+    This is traditionally used to set the option `html_theme_path`, but that should not be
+    necessary. If you install the `qiskit_sphinx_theme` via pip, you only need to set `html_theme`.
+    """
+    warn(
+        "`qiskit_sphinx_theme.get_html_theme_path()` is deprecated and will be removed in version "
+        "1.12 of the package. We are adding multiple 'variants' / theme names to the package, so "
+        "the function no longer makes semantic sense.\n\n"
+        "It should not be necessary to set the option `html_theme_path`; you only need to set "
+        "`html_theme`. See https://github.com/Qiskit/qiskit-finance/pull/244 for an example.",
+        stacklevel=2,
+        category=DeprecationWarning,
+    )
     cur_dir = path.abspath(path.dirname(path.dirname(__file__)))
     return cur_dir
 
-# See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
+
+# See https://www.sphinx-doc.org/en/master/development/theming.html
 def setup(app):
     app.add_html_theme('qiskit_sphinx_theme', path.abspath(path.dirname(__file__)))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `qiskit_sphinx_theme` package will soon have "variants" that allow setting the theme to either Core (Terra) or Ecosystem. 

When that happens, `get_html_theme_path()` will no longer make semantic sense because we will have multiple HTML themes in the package, and the user needs to choose which they want.

Turns out, setting `html_theme_path` isn't necessary in the first place. It looks like bad copy-and-paste from the Sphinx RTD theme. It has no impact on our 4 Applications consumers. See https://github.com/Qiskit/qiskit-finance/pull/244 for an example; the docs render the same before and after.

### Details and comments

I am updating all known users of `qiskit_sphinx_theme` to stop using this function. (Most don't use it already, such as Terra)