### PR TITLE
Fix deprecation due to `package_data` in `setup.py`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,4 @@ include qiskit_sphinx_theme/theme.conf
 include qiskit_sphinx_theme/*.html
 include qiskit_sphinx_theme/static/css/*.css
 include qiskit_sphinx_theme/static/js/*.js
-include qiskit_sphinx_theme/static/js/vendor/*.js
 include qiskit_sphinx_theme/static/images/*.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         "qiskit_sphinx_theme.static.js",
     ],
     include_package_data=True,
-    zip_safe=False,
     entry_points={
         'sphinx.html_themes': [
             'qiskit_sphinx_theme = qiskit_sphinx_theme',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Topic :: Internet",
-        "Topic :: Software Development :: Documentation"
+        "Topic :: Software Development :: Documentation",
+        "Framework :: Sphinx :: Theme",
     ],
     install_requires=[
        'sphinx'

--- a/setup.py
+++ b/setup.py
@@ -1,39 +1,27 @@
-"""qiskit_sphinx_theme
-
-A Sphinx theme for Qiskit that is based on the
-Pytorch Sphinx theme.
-"""
 from setuptools import setup
 
-DOCLINES = __doc__.split('\n')
-DESCRIPTION = DOCLINES[0]
-LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
-
 setup(
-    name = 'qiskit_sphinx_theme',
-    version = '1.11.0rc1',
+    name='qiskit_sphinx_theme',
+    version='1.11.0rc1',
     author="Qiskit Development Team",
     author_email="hello@qiskit.org",
     url="https://github.com/Qiskit/qiskit_sphinx_theme",
-    description=DESCRIPTION,
-    long_description=LONG_DESCRIPTION,
-    py_modules = ['qiskit_sphinx_theme'],
-    packages = ['qiskit_sphinx_theme'],
+    description="A Sphinx theme for Qiskit that is based on the Pytorch Sphinx theme.",
+    py_modules=['qiskit_sphinx_theme'],
+    packages=[
+        "qiskit_sphinx_theme",
+        "qiskit_sphinx_theme.static.css",
+        "qiskit_sphinx_theme.static.images",
+        "qiskit_sphinx_theme.static.js",
+    ],
     include_package_data=True,
     zip_safe=False,
-    package_data={'qiskit_sphinx_theme': [
-        'theme.conf',
-        '*.html',
-        'static/css/*.css',
-        'static/js/*.js',
-        'static/images/*.*',
-    ]},
-    entry_points = {
+    entry_points={
         'sphinx.html_themes': [
             'qiskit_sphinx_theme = qiskit_sphinx_theme',
-        ]
+        ],
     },
-    license= 'Apache 2',
+    license='Apache 2',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
When building `qiskit_sphinx_theme`, we would get this deprecation:

```
    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'qiskit_sphinx_theme.static.css' as an importable package,
    but it is not listed in the `packages` configuration of setuptools.

    'qiskit_sphinx_theme.static.css' has been automatically added to the distribution only
    because it may contain data files, but this behavior is likely to change
    in future versions of setuptools (and therefore is considered deprecated).

    Please make sure that 'qiskit_sphinx_theme.static.css' is included as a package by using
    the `packages` configuration field or the proper discovery methods
    (for example by using `find_namespace_packages(...)`/`find_namespace:`
    instead of `find_packages(...)`/`find:`).

    You can read more about "package discovery" and "data files" on setuptools
    documentation page.
```

As suggested by both this warning and https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data, the solution is that we should be setting the `packages` argument to list the `static` folders. 

Because we have `include_package_data=True` and those non-Python files listed in `MANIFEST.in`, they get included in the final wheel. No need for the `package_data` keyword, which was redundant with our `MANIFEST.in`. 

I confirmed this works by using `python -m build` and comparing the `qiskit_sphinx_theme-1.11.0rc1.dist-info/RECORD` entries before and after, which lists every file included in the wheel.

--

This also adds a `pyproject.toml` declaring our `[build-system]`. This is heavily encouraged by modern Python packaging.

And it removes the `zip_safe` arg, which setuptools calls "obsolete": https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html