### PR TITLE
Remove unnecessary top-level `qiskit_sphinx_theme.py`

### DIFF
--- a/qiskit_sphinx_theme.py
+++ b/qiskit_sphinx_theme.py
@@ -1,6 +1,0 @@
-from os import path
-package_dir = path.dirname(path.abspath(__file__))
-template_path = path.join(package_dir)
-
-def get_path():
-    return template_path

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/Qiskit/qiskit_sphinx_theme",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    py_modules = ['qiskit_sphinx_theme'],
+    py_modules=[],
     packages = ['qiskit_sphinx_theme'],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
I'm not totally sure why this was added in https://github.com/Qiskit/qiskit_sphinx_theme/pull/8/files. It is not necessary to fix search, which I believe was fixed by the change in `layout.html`.

This code looks like it was unused. I added a `raise ValueError()` inside `get_path()` and that never got executed when using `tox -e py -r -- -E`. 

Generally, Sphinx's HTML Theme extension would not be looking for a Python file: it expects CSS, JS, images, and `theme.conf`.