### PR TITLE
[Do not merge] Proof of concept of theme variants

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 recursive-include qiskit_sphinx_theme *.html
 recursive-include qiskit_sphinx_theme theme.conf
+graft qiskit_sphinx_theme/core_legacy_pytorch/static
+graft qiskit_sphinx_theme/ecosystem_legacy_pytorch/static
 graft qiskit_sphinx_theme/pytorch_base/static

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ import qiskit_sphinx_theme
 
 release = qiskit_sphinx_theme.__version__
 
-html_theme = 'qiskit_core__legacy_pytorch'  # use the theme in subdir 'theme'
+html_theme = 'qiskit_ecosystem__legacy_pytorch'
 templates_path = ['_templates']
 
 rst_prolog = """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ import qiskit_sphinx_theme
 
 release = qiskit_sphinx_theme.__version__
 
-html_theme = 'qiskit_sphinx_theme'  # use the theme in subdir 'theme'
+html_theme = 'qiskit_core__legacy_pytorch'  # use the theme in subdir 'theme'
 templates_path = ['_templates']
 
 rst_prolog = """

--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -32,5 +32,8 @@ def get_html_theme_path():
 
 # See https://www.sphinx-doc.org/en/master/development/theming.html
 def setup(app):
-    app.add_html_theme("qiskit_sphinx_theme", _get_theme_absolute_path("pytorch_base"))
+    legacy_pytorch_theme = _get_theme_absolute_path("pytorch_base")
+    app.add_html_theme('qiskit_sphinx_theme', legacy_pytorch_theme)
+    app.add_html_theme('qiskit_core__legacy_pytorch', legacy_pytorch_theme)
+
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -27,13 +27,22 @@ def get_html_theme_path():
         stacklevel=2,
         category=DeprecationWarning,
     )
-    return _get_theme_absolute_path("pytorch_base")
+    return _get_theme_absolute_path("core_legacy_pytorch")
 
 
 # See https://www.sphinx-doc.org/en/master/development/theming.html
 def setup(app):
-    legacy_pytorch_theme = _get_theme_absolute_path("pytorch_base")
-    app.add_html_theme('qiskit_sphinx_theme', legacy_pytorch_theme)
-    app.add_html_theme('qiskit_core__legacy_pytorch', legacy_pytorch_theme)
+    # Note: base themes should not be exposed in the entry_points for the package
+    # (in setup.py/pyproject.toml). We only need to register theme for `inherit` in `theme.conf`
+    # to work.
+    app.add_html_theme("__qiskit_pytorch_base", _get_theme_absolute_path("pytorch_base"))
+
+    core_legacy_pytorch_theme = _get_theme_absolute_path("core_legacy_pytorch")
+    app.add_html_theme('qiskit_sphinx_theme', core_legacy_pytorch_theme)
+    app.add_html_theme('qiskit_core__legacy_pytorch', core_legacy_pytorch_theme)
+
+    app.add_html_theme(
+        "qiskit_ecosystem__legacy_pytorch", _get_theme_absolute_path("ecosystem_legacy_pytorch")
+    )
 
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/qiskit_sphinx_theme/core_legacy_pytorch/footer.html
+++ b/qiskit_sphinx_theme/core_legacy_pytorch/footer.html
@@ -46,7 +46,7 @@
   {%- if show_sphinx %}
     {% trans %}
       <div>
-        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using <a href="https://github.com/Qiskit/qiskit_sphinx_theme">Qiskit Sphinx Theme </a> (based on <a href="https://github.com/pytorch/pytorch_sphinx_theme"> PyTorch Sphinx Theme</a>).
+        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using <a href="https://github.com/Qiskit/qiskit_sphinx_theme">Qiskit Sphinx Theme - Core </a> (based on <a href="https://github.com/pytorch/pytorch_sphinx_theme"> PyTorch Sphinx Theme</a>).
       </div>
     {% endtrans %}
   {%- endif %}

--- a/qiskit_sphinx_theme/core_legacy_pytorch/static/css/overrides.css
+++ b/qiskit_sphinx_theme/core_legacy_pytorch/static/css/overrides.css
@@ -1,0 +1,3 @@
+body {
+  font-family: serif;
+}

--- a/qiskit_sphinx_theme/core_legacy_pytorch/static/images/search-icon.svg
+++ b/qiskit_sphinx_theme/core_legacy_pytorch/static/images/search-icon.svg
@@ -83,7 +83,7 @@
            id="Fill-1"
            fill="#EE4C2C"
            mask="url(#mask-2)"
-           style="fill:#8a3ffc;fill-opacity:1" />
+           style="fill:#00z;fill-opacity:1" />
       </g>
     </g>
   </g>

--- a/qiskit_sphinx_theme/core_legacy_pytorch/theme.conf
+++ b/qiskit_sphinx_theme/core_legacy_pytorch/theme.conf
@@ -1,0 +1,3 @@
+[theme]
+inherit = __qiskit_pytorch_base
+stylesheet = css/theme.css, css/overrides.css

--- a/qiskit_sphinx_theme/ecosystem_legacy_pytorch/footer.html
+++ b/qiskit_sphinx_theme/ecosystem_legacy_pytorch/footer.html
@@ -1,0 +1,64 @@
+<footer>
+<!-- USER FEEDBACK -->
+  {% if analytics_enabled %}
+
+    <hr class="helpful-hr hr-top">
+      <div class="helpful-container">
+        <div class="helpful-question">Was this page helpful?</div>
+        <a class="helpful-question yes-link" onclick="clicked('yes')">Yes</a>
+        <a class="helpful-question no-link" onclick="clicked('no')">No</a>
+        <div class="was-helpful-thank-you" id="was-helpful-thank-you">Thank you!</div>
+      </div>
+    <hr class="helpful-hr hr-bottom"/>
+  
+  {% endif %}
+
+  <!-- NEXT/PREVIOUS BUTTONS -->
+  <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+    {% if next %}
+      <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="next-page"></a>
+    {% endif %}
+    {% if prev %}
+      <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="previous-page"> {{ _('Previous') }}</a>
+    {% endif %}
+  </div>
+
+  <div role="contentinfo">
+    <p>
+    <!-- SHOW QISKIT COPYRIGHT TEXT -->
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+      {%- else %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+      {%- endif %}
+    {%- endif %}
+
+    <!-- SHOW DATE PAGE LAST UPDATED -->
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+    {%- endif %}
+
+    </p>
+  </div>
+
+<!-- SHOW 'MADE WITH SPHINX' TEXT -->
+  {%- if show_sphinx %}
+    {% trans %}
+      <div>
+        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using <a href="https://github.com/Qiskit/qiskit_sphinx_theme">Qiskit Sphinx Theme - Ecosystem </a> (based on <a href="https://github.com/pytorch/pytorch_sphinx_theme"> PyTorch Sphinx Theme</a>).
+      </div>
+    {% endtrans %}
+  {%- endif %}
+
+  {%- block extrafooter %} {% endblock %}
+<br>
+</footer>
+
+<script>
+  function clicked(ctaType) {
+    document.getElementById('was-helpful-thank-you').style.visibility = 'visible';
+    window.trackCta(`Helpful - ${ctaType}`);
+  }
+</script>
+

--- a/qiskit_sphinx_theme/ecosystem_legacy_pytorch/static/css/overrides.css
+++ b/qiskit_sphinx_theme/ecosystem_legacy_pytorch/static/css/overrides.css
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}

--- a/qiskit_sphinx_theme/ecosystem_legacy_pytorch/static/images/search-icon.svg
+++ b/qiskit_sphinx_theme/ecosystem_legacy_pytorch/static/images/search-icon.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg863"
+   sodipodi:docname="search-icon.svg"
+   inkscape:version="1.0.1 (c497b03c, 2020-09-10)">
+  <metadata
+     id="metadata867">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1386"
+     inkscape:window-height="1005"
+     id="namedview865"
+     showgrid="false"
+     inkscape:zoom="45.9375"
+     inkscape:cx="3.8095238"
+     inkscape:cy="8"
+     inkscape:window-x="38"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Artboard" />
+  <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+  <desc
+     id="desc850">Created with Sketch.</desc>
+  <defs
+     id="defs853">
+    <polygon
+       id="path-1"
+       points="0 0 16 0 16 16 0 16" />
+  </defs>
+  <g
+     id="Page-1"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd">
+    <g
+       id="Artboard"
+       transform="translate(-63.000000, -93.000000)">
+      <g
+         id="ic"
+         transform="translate(63.000000, 93.000000)"
+         style="fill:#8a3ffc;fill-opacity:1">
+        <mask
+           id="mask-2"
+           fill="white">
+          <use
+             xlink:href="#path-1"
+             id="use855" />
+        </mask>
+        <g
+           id="Clip-2"
+           style="fill:#8a3ffc;fill-opacity:1" />
+        <path
+           d="M2.95913767,9.58220606 C1.13316435,7.75622206 1.13316435,4.78513897 2.95913767,2.95915497 C3.87212433,2.04616298 5.07138409,1.5896202 6.27064385,1.5896202 C7.46990361,1.5896202 8.66925692,2.04616298 9.58224358,2.95915497 C11.4082169,4.78513897 11.4082169,7.75622206 9.58224358,9.58220606 C8.69769713,10.4667577 7.52163859,10.9538926 6.27064385,10.9538926 C5.01974267,10.9538926 3.84368413,10.4667577 2.95913767,9.58220606 Z M16,14.8357224 L11.2495505,10.0852451 C13.1351173,7.62730486 12.9554949,4.08320445 10.7067543,1.83454417 C8.26070966,-0.611514724 4.28057804,-0.611514724 1.83453345,1.83454417 C-0.611511149,4.28069663 -0.611511149,8.26075796 1.83453345,10.7068169 C3.01947955,11.8917699 4.59491713,12.544308 6.27064385,12.544308 C7.66870437,12.544308 8.99594505,12.0887007 10.085841,11.2501776 L14.8356356,16 L16,14.8357224 Z"
+           id="Fill-1"
+           fill="#EE4C2C"
+           mask="url(#mask-2)"
+           style="fill:#afc;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/qiskit_sphinx_theme/ecosystem_legacy_pytorch/theme.conf
+++ b/qiskit_sphinx_theme/ecosystem_legacy_pytorch/theme.conf
@@ -1,0 +1,3 @@
+[theme]
+inherit = __qiskit_pytorch_base
+stylesheet = css/theme.css, css/overrides.css

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'sphinx.html_themes': [
             'qiskit_sphinx_theme = qiskit_sphinx_theme',
             'qiskit_core__legacy_pytorch = qiskit_sphinx_theme',
+            'qiskit_ecosystem__legacy_pytorch = qiskit_sphinx_theme',
         ],
     },
     license='Apache 2',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     entry_points={
         'sphinx.html_themes': [
             'qiskit_sphinx_theme = qiskit_sphinx_theme',
+            'qiskit_core__legacy_pytorch = qiskit_sphinx_theme',
         ],
     },
     license='Apache 2',


### PR DESCRIPTION
This sets up two theme variants: `qiskit_core__legacy_pytorch` and `qiskit_ecosystem__legacy_pytorch`. Users only need to set `html_theme` to the variant they want in `conf.py`.

For code reuse, the variants are built on top of a "base" Pytorch theme. The variants will inherit every part of this base theme, but can override things.

Images:

![Screenshot 2023-03-16 at 8 42 50 AM](https://user-images.githubusercontent.com/14852634/225670772-a520503a-a74a-4b5a-9601-e2da353ce3d9.png)

![Screenshot 2023-03-16 at 8 43 07 AM](https://user-images.githubusercontent.com/14852634/225670829-889112e4-b4a3-456c-bc2b-a229b74417a0.png)

HTML templates (see the second line, middle):

![Screenshot 2023-03-16 at 9 21 11 AM](https://user-images.githubusercontent.com/14852634/225671311-278a05db-4936-4b01-8d1d-548bfa960f18.png)

![Screenshot 2023-03-16 at 9 22 16 AM](https://user-images.githubusercontent.com/14852634/225671446-f14feb78-e08d-4e64-904b-86fa5e5967f0.png)

For CSS, we have a file `overrides.css`:

![Screenshot 2023-03-16 at 9 33 41 AM](https://user-images.githubusercontent.com/14852634/225671623-d9a1e87a-ab0e-4413-9493-c17761ec6fc8.png)

![Screenshot 2023-03-16 at 9 33 46 AM](https://user-images.githubusercontent.com/14852634/225671681-249de87a-cb72-42dd-b86e-bf886035f238.png)
