### PR TITLE
Fix margin bug at bottom of lists

### DIFF
--- a/docs/sphinx_guide/lists_tables.rst
+++ b/docs/sphinx_guide/lists_tables.rst
@@ -37,6 +37,8 @@ Enumerated Lists
 
 #. List items may also be auto-enumerated.
 
+This is some paragraph text directly after an ordered list.
+
 Definition Lists
 ----------------
 

--- a/docs/sphinx_guide/lists_tables.rst
+++ b/docs/sphinx_guide/lists_tables.rst
@@ -151,6 +151,8 @@ Simple
 
       - Still no margins
 
+This is some paragraph text directly after an unordered list.
+
 Complex
 ^^^^^^^
 
@@ -181,6 +183,7 @@ Complex
 
   This item has multiple paragraphs.
 
+This is some paragraph text directly after an unordered list.
 
 Second list level
 ^^^^^^^^^^^^^^^^^

--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -11882,9 +11882,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 .pytorch-content-left .main-content {
   padding-top: 3rem;
 }
-.pytorch-content-left .main-content ul.simple {
-  padding-bottom: 20px;
-}
+
 .pytorch-content-left .main-content .note:nth-child(1), .pytorch-content-left .main-content .warning:nth-child(1) {
   margin-top: 0;
 }

--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -10597,6 +10597,7 @@ article.pytorch-article ul,
 article.pytorch-article ol {
   padding-left: 1.0rem;
   margin: 0;
+  margin-bottom: 16px;
 }
 article.pytorch-article ul li,
 article.pytorch-article ol li {


### PR DESCRIPTION
Fixes #201. As described there, we had two issues:

1. For ordered lists, there was no margin underneath it. 
2. For unordered lists, we were adding a margin inside nested list elements, which was not intended. We only want to add a margin at the very end of the outer-most list.

This is fixed by only applying the margin to the elements `article.pytorch-article ol` and `article.pytorch-article ul`, which only apply to the outer most list. 

## Before:

<img width="472" alt="Screenshot 2023-03-17 at 11 29 35 AM" src="https://user-images.githubusercontent.com/23662430/225805307-76c22599-35b0-42a3-a57d-4db8cfc77708.png">

--


![](https://user-images.githubusercontent.com/14852634/224808178-ae18639c-503c-4224-b1db-98a23d33a94a.png)

## After:

<img width="474" alt="Screenshot 2023-03-17 at 11 28 30 AM" src="https://user-images.githubusercontent.com/23662430/225805322-53ed87a4-c70a-4254-808f-3cd9addf46fe.png">

--

![](https://user-images.githubusercontent.com/14852634/224808410-76e98eba-f90a-4859-82a1-5c9fcf27143d.png)
