### PR TITLE
Make method example header bold to match class examples

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -113,6 +113,12 @@ article.pytorch-article .sphx-glr-thumbcontainer .figure::before {
   font-weight: bold;
 }
 
+.method dd p.rubric {
+  color: #262626;
+  font-size: 110%;
+  font-weight: bold;
+}
+
 dl, ol, ul {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
fixes #202 

I haven't been able to test this fix properly yet because our local docs build doesn't include any pages that uses API class or methods.