### PR TITLE
add custom json builder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'jupyter_sphinx',
     'sphinx_design',
+    'qiskit_json_builder'
 ]
 
 # -----------------------------------------------------------------------------

--- a/docs/qiskit_json_builder.py
+++ b/docs/qiskit_json_builder.py
@@ -1,0 +1,56 @@
+import pickle
+import types
+import json
+
+from os import path
+from typing import Any, Dict
+
+from sphinx.application import ENV_PICKLE_FILENAME, Sphinx
+from sphinx.builders.html import BuildInfo, StandaloneHTMLBuilder, Builder
+from sphinx.locale import get_translation
+from sphinx.util.osutil import SEP, copyfile, ensuredir, os_path
+
+from sphinxcontrib.serializinghtml import jsonimpl, SerializingHTMLBuilder
+from sphinxcontrib.serializinghtml.version import __version__
+
+from collections import UserString
+
+import qiskit_json_impl
+
+if False:
+    # For type annotation
+    from typing import Any, Dict, Tuple  # NOQA
+
+package_dir = path.abspath(path.dirname(__file__))
+
+__ = get_translation(__name__, 'console')
+
+
+#: the filename for the "last build" file (for serializing builders)
+LAST_BUILD_FILENAME = 'last_build'
+
+class QiskitJsonBuilder(SerializingHTMLBuilder):
+    """
+    A builder that dumps the generated HTML into JSON files.
+    """
+    name = 'QiskitJsonBuilder'
+    epilog = __('You can now process the JSON files in %(outdir)s.')
+
+    implementation = qiskit_json_impl
+    implementation_dumps_unicode = True
+    indexer_format = qiskit_json_impl
+    indexer_dumps_unicode = True
+    out_suffix = '.json'
+    globalcontext_filename = 'globalcontext.json'
+    searchindex_filename = 'searchindex.json'
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.setup_extension('sphinx.builders.html')
+    app.add_builder(QiskitJsonBuilder)
+    app.add_message_catalog(__name__, path.join(package_dir, 'locales'))
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/qiskit_json_impl.py
+++ b/docs/qiskit_json_impl.py
@@ -1,10 +1,30 @@
 """
-    # TODO - given how close this is to a piece of sphinx source
-    #        does the bsd license need to be included?
-    #
-    # Heavily lifted from sphinx.util.jsonimpl but handles one
-    # specific instance of python's default json dump failing
-    # when dealing with partial objects.
+Copyright (c) 2007-2023 by the Sphinx team
+(see https://github.com/sphinx-doc/sphinx/blob/master/AUTHORS).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import json

--- a/docs/qiskit_json_impl.py
+++ b/docs/qiskit_json_impl.py
@@ -1,0 +1,54 @@
+"""
+    # TODO - given how close this is to a piece of sphinx source
+    #        does the bsd license need to be included?
+    #
+    # Heavily lifted from sphinx.util.jsonimpl but handles one
+    # specific instance of python's default json dump failing
+    # when dealing with partial objects.
+"""
+
+import json
+from collections import UserString
+
+if False:
+    # For type annotation
+    from typing import Any, IO  # NOQA
+
+
+class SphinxJSONEncoder(json.JSONEncoder):
+    """JSONEncoder subclass that forces translation proxies."""
+    def default(self, obj):
+        # type: (Any) -> str
+        if isinstance(obj, UserString):
+            return str(obj)
+        return super().default(obj)
+
+
+def dump(obj, fp, *args, **kwds):
+    # type: (Any, IO, Any, Any) -> None
+    kwds['cls'] = SphinxJSONEncoder
+    try:
+        json.dump(obj, fp, *args, **kwds)
+    except TypeError:
+        obj["translation_url"] = "placeholder for partial object"
+        json.dump(obj, fp, *args, **kwds)
+
+
+def dumps(obj, *args, **kwds):
+    # type: (Any, Any, Any) -> str
+    kwds['cls'] = SphinxJSONEncoder
+    try:
+        return json.dumps(obj, *args, **kwds)
+    except TypeError:
+        print("Failed to dump " + str(obj))
+
+
+def load(*args, **kwds):
+    # type: (Any, Any) -> Any
+    return json.load(*args, **kwds)
+
+
+def loads(*args, **kwds):
+    # type: (Any, Any) -> Any
+    return json.loads(*args, **kwds)
+


### PR DESCRIPTION
Addresses #129

Looking for feedback

Also given that the `qiskit_json_impl` is only modified to catch a specific partial object error, do we need to include copyright?

Can be run from the project base directory as `sphinx-build -b QiskitJsonBuilder ./docs ./docs/_build`