### PR TITLE
Add missing chevron on previous-next buttons (Cherry-pick of #237)

### DIFF
--- a/qiskit_sphinx_theme/footer.html
+++ b/qiskit_sphinx_theme/footer.html
@@ -16,10 +16,10 @@
   <!-- NEXT/PREVIOUS BUTTONS -->
   <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
     {% if next %}
-      <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="next-page"></a>
+      <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <img src="{{ pathto('_static/images/chevron-right-purple.svg', 1) }}" class="next-page"></a>
     {% endif %}
     {% if prev %}
-      <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><img src="{{ pathto('_static/images/chevron-right-orange.svg', 1) }}" class="previous-page"> {{ _('Previous') }}</a>
+      <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><img src="{{ pathto('_static/images/chevron-right-purple.svg', 1) }}" class="previous-page"> {{ _('Previous') }}</a>
     {% endif %}
   </div>
 

--- a/qiskit_sphinx_theme/static/css/theme.css
+++ b/qiskit_sphinx_theme/static/css/theme.css
@@ -9739,7 +9739,7 @@ a:hover {
 a.with-right-arrow, .btn.with-right-arrow {
   padding-right: 1.375rem;
   position: relative;
-  background-image: url("../images/chevron-right-orange.svg");
+  background-image: url("../images/chevron-right-purple.svg");
   background-size: 6px 13px;
   background-position: center right 5px;
   background-repeat: no-repeat;

--- a/qiskit_sphinx_theme/static/images/chevron-right-purple.svg
+++ b/qiskit_sphinx_theme/static/images/chevron-right-purple.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0.3 0.3 8.2 14.4"
+   enable-background="new 0.3 0.3 8.2 14.4"
+   xml:space="preserve"
+   sodipodi:docname="chevron-right-purple.svg"
+   inkscape:version="1.0.1 (c497b03c, 2020-09-10)"><metadata
+   id="metadata847"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs845">
+
+		</defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1237"
+   inkscape:window-height="480"
+   id="namedview843"
+   showgrid="false"
+   inkscape:zoom="51.041667"
+   inkscape:cx="4.1"
+   inkscape:cy="7.2"
+   inkscape:window-x="0"
+   inkscape:window-y="23"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="cta" />
+<title
+   id="title833">Page 1</title>
+<desc
+   id="desc835">Created with Sketch.</desc>
+<g
+   id="desktop">
+	<g
+   id="_x30_1_x5F_Home"
+   transform="translate(-864.000000, -1683.000000)">
+		<g
+   id="cta"
+   transform="translate(723,1668)">
+				<polyline
+   id="Page-1"
+   fill="none"
+   stroke="#ee4c2c"
+   stroke-width="2"
+   points="142,16 148.1,22.5 142,29     "
+   style="stroke:#8a3ffc;stroke-opacity:1" />
+			</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
This PR adds missing chevron svg file used in footer Previous/Next buttons (original image accidentally removed in #138 ). It also updates references from `chevron-right-orange` to `chevron-right-purple`, matching the fill colour used.

Updated footer rendering:

![image](https://user-images.githubusercontent.com/25207344/228622405-0e8a0ac2-f1b2-44af-be2c-85ee4ac48d52.png)

Fixes #189