### PR TITLE
Fix CI by adding `ipykernel` to requirements (Cherry-pick of #230)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+ipykernel
 jupyter-sphinx
 numpy
 matplotlib


### PR DESCRIPTION
CI started failing with

> sphinx.errors.ExtensionError: Unable to find kernel (exception: No
such kernel named python3)

I used a text comparison between our requirements installed in CI from last week vs this week. The main difference is `ipykernel` no longer showing up in the list of reqs. That is due to the patch bump of `ipywidgets` and its change here:
https://github.com/jupyter-widgets/ipywidgets/commit/785d1598b38f6fb43917489f530d14e28876fc24#commitcomment-106272180

In the meantime to them possibly reverting that change, this fixes CI.