### PR TITLE
Workaround unpkg CDN outage (Cherry-pick of #246)

### DIFF
--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -31,8 +31,8 @@
   <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
   {%- endfor -%}
 
-  <link rel="modulepreload" href="https://unpkg.com/@qiskit/web-components/experimental-bundled-ui-shell.js">
-  <script type="module" src="https://unpkg.com/@qiskit/web-components/experimental-bundled-ui-shell.js"></script>
+  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@qiskit/web-components/experimental-bundled-ui-shell.js">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@qiskit/web-components/experimental-bundled-ui-shell.js"></script>
   <style>
     qiskit-ui-shell:not(:defined) {
       display: block;


### PR DESCRIPTION
unpkg went down around 2:30 ET, causing the top nav bar to not load.

We will do a proper post-mortem. In the meantime, this fixes the top nav bar.