### PR TITLE
Fixed right sidebar bug and make sticky

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/layout.html
+++ b/qiskit_sphinx_theme/pytorch_base/layout.html
@@ -119,7 +119,7 @@
       <a href="#" class="toggle-table-of-contents" data-behavior="toggle-table-of-contents"></a>
     </div>
 
-    <!-- LEFT SIDE BAR MAIN CONTENT -->
+    <!-- left side bar main content -->
     {% include "sidebar.html" %}
 
     <div class="pytorch-container">
@@ -131,8 +131,9 @@
         </div>
       </div>
 
-      <!-- BREADCRUMB MINI MENU BELOW TOP NAV BAR -->
+      <!-- MAIN CENTRE CONTENT -->
       <section data-toggle="wy-nav-shift" id="pytorch-content-wrap" class="pytorch-content-wrap">
+        
         <div class="pytorch-content-left">
         {%- block content %}
           <div class="rst-content">

--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -11827,7 +11827,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  position: relative;
   padding-top: 0;
 }
 .pytorch-content-wrap:before, .pytorch-content-wrap:after {
@@ -11878,9 +11877,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     margin-left: 30px;
   }
 }
-.pytorch-content-left .main-content {
-  padding-top: 3rem;
-}
 .pytorch-content-left .main-content ul.simple {
   padding-bottom: 20px;
 }
@@ -11890,9 +11886,10 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 
 .pytorch-content-right {
   display: none;
-  position: relative;
   overflow-x: hidden;
   overflow-y: hidden;
+  position: sticky;
+  top: var(--header-height);
 }
 @media screen and (min-width: 1101px) {
   .pytorch-content-right {
@@ -12449,7 +12446,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   background-color: #ffffff;
   border-bottom: 1px solid #e2e2e2;
   width: 100%;
-  z-index: 201;
   height: fit-content;
 }
 @media screen and (min-width: 1101px) {
@@ -12462,8 +12458,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     padding-left: 0;
     width: 100%;
     height: fit-content;
-    position: absolute;
-    z-index: 1;
   }
   .pytorch-page-level-bar.left-menu-is-fixed {
     position: fixed;
@@ -12481,7 +12475,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     right: 0;
     width: auto;
     height: fit-content;
-    z-index: 1;
   }
   .pytorch-page-level-bar.left-menu-is-fixed {
     left: 350px;

--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -11878,9 +11878,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
     margin-left: 30px;
   }
 }
-.pytorch-content-left .main-content ul.simple {
-  padding-bottom: 20px;
-}
+
 .pytorch-content-left .main-content .note:nth-child(1), .pytorch-content-left .main-content .warning:nth-child(1) {
   margin-top: 0;
 }


### PR DESCRIPTION
In this PR:
- fixes #210 
- fixed another bug I found in the process where the breadcrumb component cuts of the main text and right sidebar when it contains long text
- made the right sidebar sticky on scroll

bug 210 fixed when language dropdown not included:
<img width="1499" alt="Screenshot 2023-04-06 at 4 16 16 PM" src="https://user-images.githubusercontent.com/23662430/230485452-94d3d823-326e-413e-8d16-ba2dc5a89e4e.png">

no regression when language dropdown enabled:
<img width="1464" alt="Screenshot 2023-04-06 at 3 42 51 PM" src="https://user-images.githubusercontent.com/23662430/230484892-b75874f4-8740-4894-8328-a9a29aff8706.png">

all content visible with a long breadcrumb:
<img width="1501" alt="Screenshot 2023-04-06 at 3 22 36 PM" src="https://user-images.githubusercontent.com/23662430/230484891-48ad3a3a-aa51-413a-ac44-839d70293980.png">

sidebar sticky on scroll:

https://user-images.githubusercontent.com/23662430/230484882-5fdd8768-92cb-4b5d-8c5a-0175f326991f.mov
