### PR TITLE
Update inline code styling

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -9827,6 +9827,8 @@ code, kbd, pre, samp {
   background-color: #f3f4f7;
   border-top: solid 2px #f3f4f7;
   border-bottom: solid 2px #f3f4f7;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 code span, kbd span, pre span, samp span {
   font-family: var(--font-family-monospace);

--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -9824,6 +9824,9 @@ a.with-right-arrow, .btn.with-right-arrow {
 
 code, kbd, pre, samp {
   font-family: var(--font-family-monospace);
+  background-color: #f3f4f7;
+  border-top: solid 2px #f3f4f7;
+  border-bottom: solid 2px #f3f4f7;
 }
 code span, kbd span, pre span, samp span {
   font-family: var(--font-family-monospace);


### PR DESCRIPTION
This closes #203 by adding CSS rules modeled after the way inline code is styled correctly in note directives.

This was the before:
<img width="855" alt="image" src="https://user-images.githubusercontent.com/3870315/231344794-0dc216a0-15a6-4ec9-86bc-283aa587bc9d.png">

This is the after:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/3870315/231344665-9f3df16d-f7b5-45ab-ae5b-897eb4977539.png">
