### PR TITLE
Add version information to breadcrumbs

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/breadcrumbs.html
+++ b/qiskit_sphinx_theme/pytorch_base/breadcrumbs.html
@@ -2,16 +2,16 @@
 
   <ul class="pytorch-breadcrumbs">
     {% block breadcrumbs %}
-    <li>
-      <a href="{{ pathto(master_doc) }}">
-        {{ project }} {{ version }} documentation
-      </a> &gt;
-    </li>
+      <li>
+        <a href="{{ pathto(master_doc) }}">
+            {{ project }} {{ version }} documentation
+        </a> &gt;
+      </li>
 
-    {% for doc in parents %}
-    <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &gt;</li>
-    {% endfor %}
-    <li>{{ title }}</li>
+        {% for doc in parents %}
+          <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &gt;</li>
+        {% endfor %}
+      <li>{{ title }}</li>
     {% endblock %}
   </ul>
 </div>

--- a/qiskit_sphinx_theme/pytorch_base/breadcrumbs.html
+++ b/qiskit_sphinx_theme/pytorch_base/breadcrumbs.html
@@ -2,16 +2,16 @@
 
   <ul class="pytorch-breadcrumbs">
     {% block breadcrumbs %}
-      <li>
-        <a href="{{ pathto(master_doc) }}">
-            {{ project }} documentation
-        </a> &gt;
-      </li>
+    <li>
+      <a href="{{ pathto(master_doc) }}">
+        {{ project }} {{ version }} documentation
+      </a> &gt;
+    </li>
 
-        {% for doc in parents %}
-          <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &gt;</li>
-        {% endfor %}
-      <li>{{ title }}</li>
+    {% for doc in parents %}
+    <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &gt;</li>
+    {% endfor %}
+    <li>{{ title }}</li>
     {% endblock %}
   </ul>
 </div>


### PR DESCRIPTION
Currently the package version is only shown on `index.html`:
![image](https://user-images.githubusercontent.com/3870315/231529768-b8f87d56-633e-42b4-bd3a-4339a992f743.png)

It would be helpful to show the version on all pages so that when users find a random page in the documentation through search engines, they don't have to dig around to find the version information. This PR adds the version to the breadcrumb such that it's on every page:

![image](https://user-images.githubusercontent.com/3870315/231530165-d7e4c0b1-d970-4dbb-9af7-c39cdbf9656e.png)

There may be better places to put the version information, but this is what I came up with.