### PR TITLE
Include `sphinxcontrib.jquery` in the project dependencies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'jupyter_sphinx',
     'sphinx_design',
+    "sphinxcontrib.jquery",
 ]
 
 # -----------------------------------------------------------------------------

--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -12,8 +12,14 @@ def get_html_theme_path():
     cur_dir = path.abspath(path.dirname(path.dirname(__file__)))
     return cur_dir
 
+
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
+    # Sphinx 6 stopped including jQuery by default. Our templates still depend on jQuery,
+    # so install it for our users automatically.
+    # TODO(#275): Instead, stop using jQuery in our themes.
+    app.setup_extension("sphinxcontrib.jquery")
+
     app.add_html_theme('qiskit_sphinx_theme', path.abspath(path.dirname(__file__)))
 
     # return explicit parallel safe

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         "Topic :: Software Development :: Documentation"
     ],
     install_requires=[
-       'sphinx'
+        "sphinx",
+        "sphinxcontrib-jquery",
     ],
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit_sphinx_theme/issues",


### PR DESCRIPTION
Sphinx 6 stopped including jQuery by default, but we're still using it in some places. As a result, the docs' functionality is broken in some places like the language selection not being clickable: https://github.com/Qiskit/qiskit_sphinx_theme/issues/272

The better fix is to stop using jQuery: https://github.com/Qiskit/qiskit_sphinx_theme/issues/275. But that is too large of a change to backport to Sphinx 1.11.

So, for now, we will release a patch version of Sphinx 1.11 that includes jQuery by default. We also try to activate the extension by default with the line `app.setup_extension("sphinxcontrib.jquery")`, but I'm having issues with that actually working. So, projects may need to still add `"sphinxcontrib.jquery"` explicitly in their `extensions` in `conf.py` - but they at least won't have to explicitly include `sphinxcontrib-jquery` in their requirements.