### PR TITLE
Include `sphinxcontrib.jquery` in the project dependencies & fix other JavaScript issues (Cherry-pick of #277)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'jupyter_sphinx',
     'sphinx_design',
+    "sphinxcontrib.jquery",
 ]
 
 # -----------------------------------------------------------------------------

--- a/qiskit_sphinx_theme/__init__.py
+++ b/qiskit_sphinx_theme/__init__.py
@@ -14,6 +14,10 @@ def get_html_theme_path():
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
+    # Sphinx 6 stopped including jQuery by default. Our Pytorch theme depend on jQuery,
+    # so install it for our users automatically.
+    app.setup_extension("sphinxcontrib.jquery")
+
     app.add_html_theme('qiskit_sphinx_theme', path.abspath(path.dirname(__file__)))
 
     # return explicit parallel safe

--- a/qiskit_sphinx_theme/languages.html
+++ b/qiskit_sphinx_theme/languages.html
@@ -13,12 +13,14 @@
     </dl>
   </div>
   <script>
-    jQuery('.version').click((evt) => {
-      const hash = window.location.hash
-      const complete_url = evt.target.href + hash
-      window.location = complete_url
-      evt.preventDefault()
-    })
+    document.querySelectorAll('.version').forEach((element) => {
+      element.addEventListener('click', (evt) => {
+        const hash = window.location.hash;
+        const complete_url = evt.target.href + hash;
+        window.location = complete_url;
+        evt.preventDefault();
+      });
+    });
   </script>
 </div>
 {% endif %}

--- a/qiskit_sphinx_theme/layout.html
+++ b/qiskit_sphinx_theme/layout.html
@@ -186,7 +186,6 @@
     $(document).ready(function() {
       mobileMenu.bind();
       mobileTOC.bind();
-      pytorchAnchors.bind();
       sideMenus.bind();
       scrollToAnchor.bind();
       highlightNavigation.bind();

--- a/qiskit_sphinx_theme/static/js/theme.js
+++ b/qiskit_sphinx_theme/static/js/theme.js
@@ -612,59 +612,9 @@ window.sideMenus = {
     }
   },
 
-  handleLeftMenu: function () {
-    var windowHeight = utilities.windowHeight();
-    var topOfFooterRelativeToWindow = document.getElementById("docs-tutorials-resources").getBoundingClientRect().top;
-
-    if (topOfFooterRelativeToWindow >= windowHeight) {
-      document.getElementById("pytorch-left-menu").style.height = "100%";
-    } else {
-      var howManyPixelsOfTheFooterAreInTheWindow = windowHeight - topOfFooterRelativeToWindow;
-      var leftMenuDifference = howManyPixelsOfTheFooterAreInTheWindow;
-      document.getElementById("pytorch-left-menu").style.height = (windowHeight - leftMenuDifference) + "px";
-    }
-  },
+  handleLeftMenu: function () {},
 
   handleRightMenu: function() {
-    var rightMenuWrapper = document.getElementById("pytorch-content-right");
-    var rightMenu = document.getElementById("pytorch-right-menu");
-    var rightMenuList = rightMenu.getElementsByTagName("ul")[0];
-    var article = document.getElementById("pytorch-article");
-    var articleHeight = article.offsetHeight;
-    var articleBottom = utilities.offset(article).top + articleHeight;
-    var mainHeaderHeight = document.getElementById('header-holder').offsetHeight;
-
-    if (utilities.scrollTop() < mainHeaderHeight) {
-      rightMenuWrapper.style.height = "100%";
-      rightMenu.style.top = 0;
-      rightMenu.classList.remove("scrolling-fixed");
-      rightMenu.classList.remove("scrolling-absolute");
-    } else {
-      if (rightMenu.classList.contains("scrolling-fixed")) {
-        var rightMenuBottom =
-          utilities.offset(rightMenuList).top + rightMenuList.offsetHeight;
-
-        if (rightMenuBottom >= articleBottom) {
-          rightMenuWrapper.style.height = articleHeight + mainHeaderHeight + "px";
-          rightMenu.style.top = utilities.scrollTop() - mainHeaderHeight + "px";
-          rightMenu.classList.add("scrolling-absolute");
-          rightMenu.classList.remove("scrolling-fixed");
-        }
-      } else {
-        rightMenuWrapper.style.height = articleHeight + mainHeaderHeight + "px";
-        rightMenu.style.top =
-          articleBottom - mainHeaderHeight - rightMenuList.offsetHeight + "px";
-        rightMenu.classList.add("scrolling-absolute");
-      }
-
-      if (utilities.scrollTop() < articleBottom - rightMenuList.offsetHeight) {
-        rightMenuWrapper.style.height = "100%";
-        rightMenu.style.top = "";
-        rightMenu.classList.remove("scrolling-absolute");
-        rightMenu.classList.add("scrolling-fixed");
-      }
-    }
-
     var rightMenuSideScroll = document.getElementById("pytorch-side-scroll-right");
     var sideScrollFromWindowTop = rightMenuSideScroll.getBoundingClientRect().top;
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         "Topic :: Software Development :: Documentation"
     ],
     install_requires=[
-       'sphinx'
+        "sphinx",
+        "sphinxcontrib-jquery",  # Remove once we get rid of the Pytorch theme.
     ],
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit_sphinx_theme/issues",


### PR DESCRIPTION
Sphinx 6 stopped including jQuery by default, but we're still using it in some places. As a result, the docs' functionality is broken in some places like the language selection not being clickable: https://github.com/Qiskit/qiskit_sphinx_theme/issues/272

I wanted to remove jQuery via
https://github.com/Qiskit/qiskit_sphinx_theme/issues/275, but it is too hard to safely due with Pytorch because we have 105 usages. We will need to wait for the switch to Furo.

So, for now, we will include jQuery by default. We also try to activate the extension by default with the line
`app.setup_extension("sphinxcontrib.jquery"),` but I'm having issues with that actually working. So, projects may need to still add `"sphinxcontrib.jquery"` explicitly in their extensions in `conf.py` - but they at least won't have to explicitly include `sphinxcontrib-jquery` in their requirements.

--

This PR also fixes other issues with our JavaScript, as reported by the developer console:

1. `languages.html` was not recognizing jQuery. So, rewrite it to modern JavaScript
2. `pytorchAnchors.bind();` was not defined so caused some of our setup to fail
3. `handleLeftMenu:` function was failing because `document.getElementById("docs-tutorials-resources")` does not exist. Since that function failed, it looks like it wasn't actually necessary anymore.