### PR TITLE
Fix links to use intersphinx

### DIFF
--- a/docs_guide/others/general_pre-requisites.rst
+++ b/docs_guide/others/general_pre-requisites.rst
@@ -1,6 +1,6 @@
 Pre-requisites
 ==============
 
-This guide assumes your project already has a working Sphinx documentation project in a
+This guide assumes your project already has a working :doc:`Sphinx <sphinx:index>` documentation project in a
 folder called ``docs`` and :ref:`the recommended folder structure <doc-structure>`. If you don't
 have it, you can set it up with :doc:`sphinx:man/sphinx-quickstart` following the tutorial :ref:`create-new-doc-project`.

--- a/docs_guide/sphinx_guide/how_to_build_docs.rst
+++ b/docs_guide/sphinx_guide/how_to_build_docs.rst
@@ -24,7 +24,7 @@ Install the Qiskit package
 --------------------------
 
 Once you have cloned the ``qiskit-x`` repository with ``git clone https://github.com/<your
-user/organization name>/qiskit-x.git``, you can install the ``qiskit_x`` package from source by going to
+user/organization_name/qiskit-x.git``, you can install the ``qiskit_x`` package from source by going to
 the root directory of your local copy and running this on your console:
 
 .. code-block:: bash
@@ -46,7 +46,7 @@ Apart from installing the ``qiskit_x`` package, there are other needed packages 
 
     pip install -r requirements-dev.txt
 
-However, there can also be some other necessary packages that are not Python, and therefore not installable with ``pip``, like `pandoc <https://pandoc.org/>`_ or graphviz `graphviz <https://graphviz.org/>`_.
+However, there can also be some other necessary packages that are not Python, and therefore not installable with ``pip``, like `pandoc <https://pandoc.org/>`_ or `graphviz <https://graphviz.org/>`_.
 You can install them with `apt-get install <https://linux.die.net/man/8/apt-get>`_:
 
 .. code-block:: bash

--- a/docs_guide/sphinx_guide/rst.rst
+++ b/docs_guide/sphinx_guide/rst.rst
@@ -22,11 +22,11 @@ Why do we use reStructuredText in Qiskit?
 =========================================
 
 The main reason we are using reStructuredText in Qiskit is that it is the native language of
-`Sphinx <https://www.sphinx-doc.org/en/master/>`_, the documentation generator used in Qiskit.
+:doc:`Sphinx <sphinx:index>`, the documentation generator used in Qiskit.
 Using other languages requires converation to RST, which is generally less efficient than using RST from the start and can occasionally cause `unintended formatting issues <https://github.com/spatialaudio/nbsphinx/issues/301>`_.
 
 Because RST is the native language for Sphinx, comparing with other options like `Jupyter notebooks <https://jupyter.org/>`_ (``.ipynb`` files) or `Markdown <https://daringfireball.net/projects/markdown/>`_ (``.md`` files), writing documentation in RST has the great benefit of automatic cross-referencing to other sections or files within the documentation. So if a page has been moved, the documentation will automatically change accordingly. And if a cross-reference link is broken, it can be caught in the docs building process. All of these means documentation maintenance is much easier with RST. 
 
 Jupyter notebooks have one functionality that is better than RST, that is the ease of running code cells. In addition, our users are familiar with using Jupyter notebooks to execute codes. Therefore, tutorials at the moment are mostly written in Jupyter notebooks. However, in addition to no cross-referencing, Jupyter notebooks are difficult to maintain because it is not written in plaintext. It is hard to review changes. 
 
-In the future, we hope to use only RST for documentation (including tutorials). There are ways to execute Python code within RST (using `doctest <https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html>`_ or `jupyter-sphinx <https://jupyter-sphinx.readthedocs.io/en/latest/>`_ extension) and expose output Jupyter notebooks for users to download while Markdown doesn't offer any of these options.
+In the future, we hope to use only RST for documentation (including tutorials). There are ways to execute Python code within RST (using :doc:`doctest <sphinx:usage/extensions/doctest>` or `jupyter-sphinx <https://jupyter-sphinx.readthedocs.io/en/latest/>`_ extension) and expose output Jupyter notebooks for users to download while Markdown doesn't offer any of these options.

--- a/docs_guide/sphinx_guide/sphinx.rst
+++ b/docs_guide/sphinx_guide/sphinx.rst
@@ -7,7 +7,7 @@ Sphinx
 What is Sphinx?
 ===============
 
-`Sphinx <https://www.sphinx-doc.org/en/master/>`_ is a documentation generator that converts `reStructuredText <https://docutils.sourceforge.io/rst.html>`_ (RST) files to formats like `HTML <https://html.spec.whatwg.org/multipage/>`_, `LaTeX <https://www.latex-project.org/>`_, `ePub <https://www.w3.org/publishing/epub32/>`_, `Texinfo <https://www.gnu.org/software/texinfo/>`_, manual pages or plain text.
+:doc:`Sphinx <sphinx:index>` is a documentation generator that converts `reStructuredText <https://docutils.sourceforge.io/rst.html>`_ (RST) files to formats like `HTML <https://html.spec.whatwg.org/multipage/>`_, `LaTeX <https://www.latex-project.org/>`_, `ePub <https://www.w3.org/publishing/epub32/>`_, `Texinfo <https://www.gnu.org/software/texinfo/>`_, manual pages or plain text.
 It is written in Python. Some of its main characteristics are:
 
 * Ability to cross-reference to pages corresponding to functions, classes, attributes, parameters and similar, creating links with semantic markup.
@@ -26,10 +26,10 @@ URL from the deployed page, so you reduce the risk of broken links to a minimum 
 
 Sphinx also offers a wide array of extensions that make creating docs much easier, like the following:
 
-* `instersphinx <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_, that enables you to link to other projects, like other Qiskit repositories.
-* `napoleon <https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html>`_, that lets you use `NumPy <https://numpydoc.readthedocs.io/en/latest/format.html>`_ and `Google <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_ style docstrings, simpler than using `pure RST <https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html>`_.
-* `autodoc <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_, that automatically creates module pages.
-* `autosummary <https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>`_, that creates summary tables for functions, methods, attributes or parameters from their source code, avoiding duplication of content.
+* :doc:`intersphinx <sphinx:usage/extensions/intersphinx>`, that enables you to link to other projects, like other Qiskit repositories.
+* :doc:`napoleon <sphinx:usage/extensions/napoleon>`, that lets you use `NumPy <https://numpydoc.readthedocs.io/en/latest/format.html>`_ and `Google <https://google.github.io/styleguide/pyguide.html#383-functions-and-methods>`_ style docstrings, simpler than using `pure RST <https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html>`_.
+* :doc:`autodoc <sphinx:usage/extensions/autodoc>`, that automatically creates module pages.
+* :doc:`autosummary <sphinx:usage/extensions/autosummary>`, that creates summary tables for functions, methods, attributes or parameters from their source code, avoiding duplication of content.
 * `reno.sphinxext <https://docs.openstack.org/reno/2.1.1/sphinxext.html>`_, that incorporates release notes to the documentation automatically.
 * `jupyter_sphinx <https://jupyter-sphinx.readthedocs.io/en/latest/>`_, that allows you to run Jupyter cells.
 


### PR DESCRIPTION
This PR updates several Sphinx-related links to use intersphinx.

It also adds a link to the Sphinx home page in pre-requisites.

There were some cases in which I used the `:doc:` directive instead of `:mod:` so that the links looked consistent when mixed with standard links that correspond to extensions that are not included in `intersphinx_mapping` like `jupyter-sphinx` or `nbsphinx`.