### PR TITLE
Fix regression in sticky page table of contents

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -42,6 +42,9 @@ contents. */
   --breakpoint-xl: 1200px;
   --font-family-sans-serif: "IBM Plex Sans", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-family-monospace: "IBM Plex Mono", Consolas, "Courier New", monospace;
+  /* This value is duplicated from `top-nav-bar.js`. Its definition of the variable is not exposed
+   * globally. Keep in sync. */
+  --header-height: 3.5rem;
 }
 
 section {


### PR DESCRIPTION
## Problem

Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/293. https://github.com/Qiskit/qiskit_sphinx_theme/pull/274 broke some of our CSS by removing the definition of `--header-height` in `theme.css`.

While it is true that `top-nav-bar.js` defines the CSS variable `--header-height`, I did not realize that it does not expose the variable globally. It uses a "shadow DOM" for encapsulation. That is a good thing! But, it means we need to define `--header-height` ourselves to use it in our own styling.

## Solution

I considered trying to dynamically compute the `--header-height` based on inspecting the `.offsetHeight` of `<qiskit-ui-shell>`. Unfortunately, we can only do this with JavaScript; the (ChatGPT-suggested) code made the project more complex.

Instead, I took the simpler approach of copying the value `3.5rem` from `top-nav-bar.js`. While this duplication is bad (Don't Repeat Yourself), we expect the value `3.5rem` to be stable and the complexity of dynamically computing the value seemed even worse.