### PR TITLE
fixed text wrap for long function names

### DIFF
--- a/example_docs/api_example/electron.py
+++ b/example_docs/api_example/electron.py
@@ -30,3 +30,6 @@ class Electron:
         :return: The computed momentum.
         :raises ValueError: You did something wrong
         """
+    
+    def method_with_a_reallyyreallreallyreallyreallyreallyreallreallyreallyreallyreally_long_title(self):
+        """blahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblahblah"""

--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -10637,6 +10637,7 @@ article.pytorch-article h4,
 article.pytorch-article h5,
 article.pytorch-article h6 {
   font-weight: 400;
+  word-wrap: break-word;
 }
 article.pytorch-article h1 a,
 article.pytorch-article h2 a,


### PR DESCRIPTION
fixes #260 

before:
<img width="1380" alt="Screenshot 2023-05-05 at 11 32 47 AM" src="https://user-images.githubusercontent.com/23662430/236524617-dc847bd3-05fe-4289-88c6-7097b4482a20.png">


after:
<img width="1119" alt="Screenshot 2023-05-05 at 11 32 37 AM" src="https://user-images.githubusercontent.com/23662430/236524640-ef06c187-b67e-4d57-857d-a4d56d909c85.png">
