### PR TITLE
Fix Previous Releases section not being clickable

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/sidebar.html
+++ b/qiskit_sphinx_theme/pytorch_base/sidebar.html
@@ -87,7 +87,7 @@
 
     // expand and unexpand previous releases dropdown when clicked
     var release_rows = document.getElementsByClassName("sidebar-l1-expandable");
-    for (i = 0; i < expandable_rows.length; i++) {
+    for (i = 0; i < release_rows.length; i++) {
         release_rows[i].addEventListener("click", function() {
             this.classList.toggle("open");
             var clicked_subheadings = this.nextElementSibling;


### PR DESCRIPTION
This bug caused the sidebar for Previous Releases to not be clickable on Rustworkx. (For some reason, it doesn't impact qiskit-metapackage)

![Screenshot 2023-05-08 at 12 59 24 PM](https://user-images.githubusercontent.com/14852634/236909294-eede5406-f8ad-40ec-b419-3d7bedbdcfe9.png)
