### PR TITLE
Disable dark mode for Furo

### DIFF
--- a/qiskit_sphinx_theme/furo/base/custom_templates/extra_head.html
+++ b/qiskit_sphinx_theme/furo/base/custom_templates/extra_head.html
@@ -3,6 +3,12 @@
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&family=IBM+Plex+Sans:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
 <script src="{{ pathto('_static/js/web-components/top-nav-bar.js', 1) }}"></script>
 <script type="text/javascript" src="{{ pathto('_static/js/utils.js', 1) }}"></script>
+<script>
+  {#- Force light mode. -#}
+  document.addEventListener("DOMContentLoaded", function () {
+    document.body.setAttribute("data-theme", "light");
+  });
+</script>
 
 {%- if analytics_enabled %}
 <script>

--- a/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
+++ b/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
@@ -18,6 +18,11 @@ body {
 * Top nav bar
 * ------------------------------ */
 
+/* Disable dark mode until qiskit.org has it: https://github.com/Qiskit/qiskit.org/issues/2310 */
+.theme-toggle-container {
+  display: none;
+}
+
 /* Fix Qiskit top nav bar hiding Furo's top nav bar when scrolled down. */
 .mobile-header,
 .sidebar-sticky,


### PR DESCRIPTION
We decided in https://github.com/Qiskit/qiskit_sphinx_theme/issues/273 to disable dark mode for Furo until we have it for qiskit.org in general. Tracked by https://github.com/Qiskit/qiskit.org/issues/2310.

This PR hides the dark mode icon and also forces the site to render with light mode. Even when I change my OS to use dark mode, we still get light docs; unlike when I go to pip's docs.

Before:

![Screenshot 2023-05-10 at 12 28 48 PM](https://github.com/Qiskit/qiskit_sphinx_theme/assets/14852634/f76548c2-78c9-4221-ae4a-71e5fd287055)

--

After:

![Screenshot 2023-05-10 at 12 28 13 PM](https://github.com/Qiskit/qiskit_sphinx_theme/assets/14852634/0df669d7-ec9b-45c2-a95c-ca0f68adbccb)

