### PR TITLE
Remove VCS dependency on Furo due to packaging issue (Cherry-pick of #331)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ sphinx-design
 sphinx-autodoc-typehints
 nbsphinx==0.9.*
 pytest==7.*
+# Move to setup.py once they do a stable release.
+furo @ git+https://github.com/pradyunsg/furo.git@48c0bf2aa983fb1ccd79b4167fe85387249afedf

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     ],
     install_requires=[
         "docutils",
-        "furo @ git+https://github.com/pradyunsg/furo.git@48c0bf2aa983fb1ccd79b4167fe85387249afedf",
         "sphinx",
         "sphinxcontrib-jquery",  # Remove once we get rid of the Pytorch theme.
     ],


### PR DESCRIPTION
I didn't realize PyPI bans `install_requires` having a VCS (version control system) requirement. That's a good ban, but it broke the 1.12.0rc1 release.

The workaround is to remove Furo from our `setup.py`. You don't need Furo installed to use our normal Pytorch theme, only to use the experiment `_qiskit_furo` theme. The docs still build even without Furo thanks to conditional imports:


https://github.com/Qiskit/qiskit_sphinx_theme/blob/770d3b658a172d1b6e075e253901b8e141aac46e/qiskit_sphinx_theme/__init__.py#L63-L70

If you do want to use Furo, then you can still install it manually by e.g. adding it to your `requirements-dev.txt`. All our theme cares about is that Furo is in the virtual environment. It doesn't care how it got there.

Once Furo has a stable release, we will move the requirement back to setup.py. Tracked by
https://github.com/Qiskit/qiskit_sphinx_theme/issues/330.