### PR TITLE
Fix regression of code links being blue (Cherry-pick of #336)

### DIFF
--- a/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
+++ b/qiskit_sphinx_theme/pytorch_base/static/css/theme.css
@@ -9859,11 +9859,6 @@ a:visited code.highlighter-rouge,
 a:hover code.highlighter-rouge {
   color: #4974D1;
 }
-a:link.has-code,
-a:visited.has-code,
-a:hover.has-code {
-  color: #4974D1;
-}
 
 p code,
 h1 code,
@@ -10595,17 +10590,6 @@ a.headerlink {
 
 a.headerlink:hover{
   color: var(--purple) !important;
-}
-
-a:link.has-code,
-a:hover.has-code,
-a:visited.has-code {
-  color: #4974D1;
-}
-a:link.has-code span,
-a:hover.has-code span,
-a:visited.has-code span {
-  color: #4974D1;
 }
 
 article.pytorch-article ul,


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/335.

I git bisected this to
https://github.com/Qiskit/qiskit_sphinx_theme/pull/292. Before, we weren't actually fully running `theme.js` because JavaScript errors prevented the file from fully executing. @coruscating identified that before the regression, the HTML elements did not have the class `.has-code`, but after they did. I suspect `theme.js` is responsible for that (but I couldn't figure out how!)

Either way, these rules about `.has-code` are bad. We should not be setting links to be blue.