### PR TITLE
Add Furo to install_requires and bump Sphinx requirement to 6.0+

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,3 @@ sphinx-design
 sphinx-autodoc-typehints
 nbsphinx==0.9.*
 pytest==7.*
-# Move to setup.py once they do a stable release.
-furo @ git+https://github.com/pradyunsg/furo.git@48c0bf2aa983fb1ccd79b4167fe85387249afedf

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,13 @@ setup(
     ],
     install_requires=[
         "docutils",
-        "sphinx",
-        "sphinxcontrib-jquery",  # Remove once we get rid of the Pytorch theme.
+        # Keep in sync with Furo's constraint.
+        "sphinx>=6.0",
+        # Remove jQuery once we get rid of the Pytorch theme.
+        "sphinxcontrib-jquery",
+        # When upgrading Furo, closely analyze each commit in the release to check for any changes
+        # that would break our fork.
+        "furo==2023.5.20",
     ],
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit_sphinx_theme/issues",


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/330.

While we might not be ready to fully switch all production users to Furo in Theme 1.13, we at least will have made enough progress that it is ready for them to try it out. We want to make that setup easier.

The main change that impacts us from the prior release (https://github.com/pradyunsg/furo/commits/2023.05.20) is that Furo now requires Sphinx 6.0+. Note that Sphinx 6 drops Python 3.7. Most Qiskit projects have already made this change, but not all yet. So we probably need to coordinate this PR with those projects.