### PR TITLE
Furo: fix anchor tags scrolling

### DIFF
--- a/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
+++ b/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
@@ -30,6 +30,24 @@ body {
   top: var(--qiskit-top-nav-bar-height);
 }
 
+/* Fix # anchor links not accounting for the top nav bar.
+*
+* The rules for mobile come from Furo, but we add --qiskit-top-nav-bar-height.
+* But for some reason, the default rule has too much spacing if we include Furo's original rule's
+* --header-height. */
+:target {
+  scroll-margin-top: var(--qiskit-top-nav-bar-height);
+}
+@media (max-width: 67em) {
+  :target {
+     scroll-margin-top: calc(0.5rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
+  }
+  /* When a heading is selected */
+  section > span:target {
+    scroll-margin-top: calc(0.8rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
+  }
+}
+
 /* Show the whole contents of the mobile expandable menus.
 *  `box-sizing: border-box` ensures padding is included in the height calculations. */
 @media (max-width: 67em) {


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/298. Before, when opening a URL with anchor tags, like `my_page.html#subheading1`, the top nav bar would cut off the content.

Furo already had rules for scrolling with anchor tags, but they don't account for our `--qiskit-top-nav-bar-height`. So, we override them to get the same behavior as default Furo (e.g. pip docs).

After, desktop:

![Screenshot 2023-05-24 at 11 39 02 AM](https://github.com/Qiskit/qiskit_sphinx_theme/assets/14852634/54e1eb19-df20-40cc-acaf-ee635b8dca90)

After, mobile:

![Screenshot 2023-05-24 at 11 39 26 AM](https://github.com/Qiskit/qiskit_sphinx_theme/assets/14852634/082e6597-e384-4bfb-9865-61f88c9ac69e)
