### PR TITLE
[blocked] Add live previews of Furo docs to PRs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+/.tox
+/.venv
+/venv
+/node_modules
+__pycache__/
+
+/example_docs/docs/_build/
+/example_docs/docs/stubs/
+/docs_guide

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,5 +1,8 @@
 # This Action builds the example docs in pull requests so that we can view a live preview.
 # It uses IBM Cloud to build the Dockerfile at the root of the repository.
+#
+# Due to security, this can only run on branches of qiskit-sphinx-theme, i.e. not on forks.
+# We skip the actions if running on a fork.
 
 name: Preview
 
@@ -11,7 +14,7 @@ jobs:
   setup:
     if: |
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') &&
-      github.repository_owner == 'Qiskit'
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
     with:
       code_engine_project: qiskit-sphinx-theme-preview
@@ -22,7 +25,9 @@ jobs:
       ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
 
   teardown:
-    if: github.event.action == 'closed' && github.repository_owner == 'Qiskit'
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: Qiskit/gh-actions/.github/workflows/code-engine-cleanup.yml@main
     with:
       code_engine_project: qiskit-sphinx-theme-preview

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,0 +1,32 @@
+# This Action builds the example docs in pull requests so that we can view a live preview.
+# It uses IBM Cloud to build the Dockerfile at the root of the repository.
+
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+jobs:
+  setup:
+    if: |
+      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') &&
+      github.repository_owner == 'Qiskit'
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+    with:
+      code_engine_project: qiskit-sphinx-theme-preview
+      docker_image_name: qiskit-sphinx-theme
+      docker_image_port: "8000"
+    secrets:
+      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+
+  teardown:
+    if: github.event.action == 'closed' && github.repository_owner == 'Qiskit'
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-cleanup.yml@main
+    with:
+      code_engine_project: qiskit-sphinx-theme-preview
+      docker_image_name: qiskit-sphinx-theme
+    secrets:
+      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# This Dockerfile is used to preview the docs in pull requests via GitHub Actions.
+#
+# To test it out locally:
+#
+#   1. ❯ docker build -t sphinx-docs-preview .
+#   2. ❯ docker run --rm -p 8000:8000 -t sphinx-docs-preview
+#   3. Open up localhost:8000
+
+FROM python:3.9
+
+RUN apt-get update && apt-get install -y pandoc graphviz
+RUN python -m pip install -U tox
+
+WORKDIR /app
+
+COPY . .
+
+RUN THEME=_qiskit_furo tox run -e docs
+
+EXPOSE 8000
+CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_build/html"]


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/261.

This uses IBM Cloud and the actions at https://github.com/Qiskit/gh-actions, like we do with platypus (textbook) and qiskit.org. We manually set up the project and API key in IBM Cloud, then stored the secrets using GitHub Actions Secrets.

For now, this only adds a preview of Furo, not Pytorch. See https://github.com/Qiskit/qiskit_sphinx_theme/issues/348 to track that. We will probably want to figure that out before we add the Ecosystem Theme Variant.