### PR TITLE
[wip] Furo: Add Previous Releases feature

### DIFF
--- a/example_docs/docs/index.rst
+++ b/example_docs/docs/index.rst
@@ -12,10 +12,12 @@ Qiskit sphinx theme |version| documentation
    sphinx_guide/tables
    sphinx_guide/panels
    sphinx_guide/images
+   sphinx_guide/paragraph
+   sphinx_guide/structural
 
 .. toctree::
   :hidden:
-  :caption: API (An Expandable Section)
+  :caption: API
 
    Functions <sphinx_guide/functions>
    Autodoc <sphinx_guide/autodoc>
@@ -23,10 +25,9 @@ Qiskit sphinx theme |version| documentation
 
 .. toctree::
    :hidden:
+   :caption: Special elements
 
    sphinx_guide/jupyter
-   sphinx_guide/paragraph
-   sphinx_guide/structural
    sphinx_guide/notebook_gallery
    sphinx_guide/custom_directives
    sphinx_guide/long_title

--- a/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
+++ b/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
@@ -1,12 +1,11 @@
 {% if version_list %}
     <div class="sidebar-tree">
-        <p class="caption" role="heading"><span class="caption-text">Previous Releases</span></p>
         <ul>
             <li class="toctree-l1 has-children">
-                <a class="reference internal" href="autodoc.html">Versions</a>
-                <input class="toctree-checkbox" id="toctree-checkbox-previous-versions" name="toctree-checkbox-previous-versions" role="switch" type="checkbox">
-                <label for="toctree-checkbox-previous-versions">
-                    <div class="visually-hidden">Toggle navigation of Previous Versions</div>
+                <a class="reference internal" href="autodoc.html">Previous Releases</a>
+                <input class="toctree-checkbox" id="toctree-checkbox-previous-releases" name="toctree-checkbox-previous-releases" role="switch" type="checkbox">
+                <label for="toctree-checkbox-previous-releases">
+                    <div class="visually-hidden">Toggle navigation of Previous Releases</div>
                     <i class="icon"><svg><use href="#svg-arrow-right"></use></svg></i>
                 </label>
                 <ul>

--- a/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
+++ b/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
@@ -1,10 +1,12 @@
 {% if version_list %}
-    <div>Previous Releases</div>
-    <div>
+    <div class="sidebar-tree">
+        <p class="caption" role="heading"><span class="caption-text">Previous Releases</span></p>
+        <ul>
         {% for version in version_list | sort(reverse=True) %}
-            <div>
-                <a href="{{ previous_versions_url(version) }}" rel="nofollow">{{ version }}</a>
-            </div>
+            <li class="toctree-l1">
+                <a class="reference internal" href="{{ previous_versions_url(version) }}" rel="nofollow">{{ version }}</a>
+            </li>
         {% endfor %}
+        </ul>
     </div>
 {% endif %}

--- a/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
+++ b/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
@@ -1,8 +1,8 @@
 {% if version_list %}
-    <div class="sidebar-l1-expandable">Previous Releases</div>
-    <div class="sidebar-subheadings">
+    <div>Previous Releases</div>
+    <div>
         {% for version in version_list | sort(reverse=True) %}
-            <div class="sidebar-l2">
+            <div>
                 <a href="{{ previous_versions_url(version) }}" rel="nofollow">{{ version }}</a>
             </div>
         {% endfor %}

--- a/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
+++ b/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
@@ -2,7 +2,7 @@
     <div class="sidebar-tree">
         <ul>
             <li class="toctree-l1 has-children">
-                <a class="reference internal" href="autodoc.html">Previous Releases</a>
+                <p class="reference internal qiskit-previous-releases-caption">Previous Releases</p>
                 <input class="toctree-checkbox" id="toctree-checkbox-previous-releases" name="toctree-checkbox-previous-releases" role="switch" type="checkbox">
                 <label for="toctree-checkbox-previous-releases">
                     <div class="visually-hidden">Toggle navigation of Previous Releases</div>

--- a/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
+++ b/qiskit_sphinx_theme/furo/base/custom_templates/sidebar_version_list.html
@@ -2,11 +2,20 @@
     <div class="sidebar-tree">
         <p class="caption" role="heading"><span class="caption-text">Previous Releases</span></p>
         <ul>
-        {% for version in version_list | sort(reverse=True) %}
-            <li class="toctree-l1">
-                <a class="reference internal" href="{{ previous_versions_url(version) }}" rel="nofollow">{{ version }}</a>
-            </li>
-        {% endfor %}
+            <li class="toctree-l1 has-children">
+                <a class="reference internal" href="autodoc.html">Versions</a>
+                <input class="toctree-checkbox" id="toctree-checkbox-previous-versions" name="toctree-checkbox-previous-versions" role="switch" type="checkbox">
+                <label for="toctree-checkbox-previous-versions">
+                    <div class="visually-hidden">Toggle navigation of Previous Versions</div>
+                    <i class="icon"><svg><use href="#svg-arrow-right"></use></svg></i>
+                </label>
+                <ul>
+                {% for version in version_list | sort(reverse=True) %}
+                    <li class="toctree-l2">
+                        <a class="reference internal" href="{{ previous_versions_url(version) }}" rel="nofollow">{{ version }}</a>
+                    </li>
+                {% endfor %}
+                </ul>
         </ul>
     </div>
 {% endif %}

--- a/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
+++ b/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
@@ -64,6 +64,26 @@ body {
 }
 
 /* ------------------------------
+* Left side bar
+* ------------------------------ */
+
+/* The Previous Releases page is not a standalone page; you cannot click it. You only can expand
+* the section to see its subpages. This is unlike typical Furo table of contents entries,
+* where you can both go to subpages and the top-level page.
+*
+* We use the CSS classes `internal` and `reference` on our "Previous Releases" <p> element because
+* it gets the right spacing for the expand/collapse button. But, we need to overwrite the styling
+* so that it doesn't look like you can click the top-level page entry itself. We make this instead
+* look like a Table of Contents section header; we copy the CSS rules for
+* `.sidebar-tree .caption, .sidebar-tree :not(.caption)>.caption-text`. */
+.sidebar-tree li.has-children > .qiskit-previous-releases-caption {
+  color: var(--color-sidebar-caption-text);
+  font-size: var(--sidebar-caption-font-size);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+/* ------------------------------
 * User analytics in the footer
 * ------------------------------ */
 

--- a/qiskit_sphinx_theme/furo/base/theme.conf
+++ b/qiskit_sphinx_theme/furo/base/theme.conf
@@ -12,4 +12,5 @@ sidebars =
   sidebar/search.html,
   sidebar/scroll-start.html,
   sidebar/navigation.html,
+  custom_templates/sidebar_version_list.html,
   sidebar/scroll-end.html


### PR DESCRIPTION
We use a different HTML structure than Furo, with having the `label` over the entire container rather than only the chevron icon so that it's all clickable. As a result, we can't easily reuse Furo's HTML and CSS classes. Instead, we copy the relevant rules as inspiration.

Because this HTML template is specific to Furo, this has no impact on Pytorch.

## Design choice: no top-level page

Normally, Furo expects the top-level page to be clickable, like this:

![Screenshot 2023-06-02 at 10 28 59 AM](https://github.com/Qiskit/qiskit_sphinx_theme/assets/14852634/5755bb10-2472-402d-95d5-61c6f9423c2d)

I decided it would be too complex and repetitive to auto-generate a page like that to simply list all the versions.

So instead, I tweaked the CSS for our top-level `Previous Releases` caption to emulate Furo's section headers. It's important that it stands out because we soon will change top-level pages to not use purple: https://github.com/Qiskit/qiskit_sphinx_theme/issues/343. We need to make clear this is not a normal clickable link, and color alone is not enough.

## Design choice: collapsible section

My first implementation had a flat list of versions. But it was important in Pytorch to have Previous Versions be collapsible and collapsed by default. Some of our projects have lots of versions, so the left sidebar would get too big.

## Tweaks example_docs table of contents

To make our example docs more clear, this adds a new Special Elements section. On Pytorch, that results in the ToC looking like this:

![pytorch-sidebar](https://github.com/Qiskit/qiskit_sphinx_theme/assets/14852634/8faeb393-35a6-4bc5-8868-15e0082c4030)
