### PR TITLE
Fix Qiskit top nav bar covering site when scrolled down

### DIFF
--- a/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
+++ b/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
@@ -24,7 +24,7 @@ body {
   display: none;
 }
 
-/* Fix Qiskit top nav bar hiding Furo's top nav bar when scrolled down. */
+/* Fix Qiskit top nav bar hiding Furo's top nav bar and side menus. */
 .mobile-header,
 .sidebar-sticky,
 .toc-sticky,
@@ -41,6 +41,16 @@ body {
   .toc-drawer {
     top: var(--qiskit-top-nav-bar-height);
   }
+}
+
+/* These are also necessary to fix the Qiskit top nav bar hiding Furo content/menus, specifically
+*  when the user is scrolled down to the bottom of the page. They override Furo's rules. */
+.sidebar-sticky,
+.toc-sticky {
+  height: calc(100vh - var(--qiskit-top-nav-bar-height));
+}
+.toc-scroll {
+  max-height: calc(100vh - var(--qiskit-top-nav-bar-height));
 }
 
 /* Fix # anchor links not accounting for the top nav bar.

--- a/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
+++ b/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
@@ -27,8 +27,20 @@ body {
 /* Fix Qiskit top nav bar hiding Furo's top nav bar when scrolled down. */
 .mobile-header,
 .sidebar-sticky,
-.toc-sticky {
+.toc-sticky,
+#__navigation:checked ~ .page .sidebar-drawer,
+#__toc:checked ~ .page .toc-drawer {
   top: var(--qiskit-top-nav-bar-height);
+}
+@media (max-width: 67em) {
+  .sidebar-drawer {
+    top: var(--qiskit-top-nav-bar-height);
+  }
+}
+@media (max-width: 82em) {
+  .toc-drawer {
+    top: var(--qiskit-top-nav-bar-height);
+  }
 }
 
 /* Fix # anchor links not accounting for the top nav bar.
@@ -46,21 +58,6 @@ body {
   /* When a heading is selected */
   section > span:target {
     scroll-margin-top: calc(0.8rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
-  }
-}
-
-/* Show the whole contents of the mobile expandable menus.
-*  `box-sizing: border-box` ensures padding is included in the height calculations. */
-@media (max-width: 67em) {
-  .sidebar-drawer {
-    padding-top: var(--qiskit-top-nav-bar-height);
-    box-sizing: border-box;
-  }
-}
-@media (max-width: 82em) {
-  .toc-drawer {
-    padding-top: var(--qiskit-top-nav-bar-height);
-    box-sizing: border-box;
   }
 }
 

--- a/tests/js/snapshots.test.js
+++ b/tests/js/snapshots.test.js
@@ -4,6 +4,10 @@ import { expect, test } from "@playwright/test";
 // Helper functions
 // -----------------------------------------------------------------------
 
+const setDesktop = async (page) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+};
+
 const setMobile = async (page) => {
   await page.setViewportSize({ width: 375, height: 812 });
 };
@@ -52,26 +56,37 @@ test.describe("Qiskit top nav bar", () => {
     page,
   }) => {
     await page.goto("sphinx_guide/lists.html");
+
+    const check = async () => {
+      const pageToCVisible = await isVisibleInViewport(
+        page,
+        "div.toc-title-container"
+      );
+      expect(pageToCVisible).toBe(true);
+
+      const searchVisible = await isVisibleInViewport(
+        page,
+        "input.sidebar-search"
+      );
+      expect(searchVisible).toBe(true);
+
+      await setMobile(page);
+      const mobileHeaderVisible = await isVisibleInViewport(
+        page,
+        "header.mobile-header"
+      );
+      expect(mobileHeaderVisible).toBe(true);
+    };
+
+    // First check after scrolling down a little bit.
     await scrollDown(page, 200);
+    await check();
 
-    const pageToCVisible = await isVisibleInViewport(
-      page,
-      "div.toc-title-container"
-    );
-    expect(pageToCVisible).toBe(true);
-
-    const searchVisible = await isVisibleInViewport(
-      page,
-      "input.sidebar-search"
-    );
-    expect(searchVisible).toBe(true);
-
-    await setMobile(page);
-    const mobileHeaderVisible = await isVisibleInViewport(
-      page,
-      "header.mobile-header"
-    );
-    expect(mobileHeaderVisible).toBe(true);
+    // Then scroll to the bottom of the page. We use the home page because it's short.
+    await setDesktop(page);
+    await page.goto("");
+    await scrollDown(page, 1000);
+    await check();
   });
 
   test("does not cover the top of # anchor links", async ({ page }) => {


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/369. If you scrolled all the way down the page, we hid the top of the site like the search bar:


![](https://user-images.githubusercontent.com/14852634/244439530-ed104013-caf5-4329-952f-571443f6f8eb.png)

This PR also improves the previous implementation of the expanded side menus being covered. Now, we override Furo's default rules to consider `--qiskit-top-nav-bar-height`.