### PR TITLE
Turn off scroll for Furo anchor links

### DIFF
--- a/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
+++ b/qiskit_sphinx_theme/furo/base/static/styles/qiskit_changes.css
@@ -29,6 +29,11 @@ body {
     --qiskit-color-purple: #6929C4;
 }
 
+/* Turn off scroll animation for anchor links: https://github.com/pradyunsg/furo/discussions/384 */
+html {
+  scroll-behavior: auto;
+}
+
 /* ------------------------------------------------------------------------------
 * Top nav bar
 * ------------------------------------------------------------------------------- */

--- a/tests/js/snapshots.test.js
+++ b/tests/js/snapshots.test.js
@@ -98,8 +98,6 @@ test.describe("Qiskit top nav bar", () => {
   test("does not cover the top of # anchor links", async ({ page }) => {
     const checkHeader = async () => {
       await page.goto("sphinx_guide/lists.html#definition-lists");
-      // We have to wait for the page animation to update.
-      await page.waitForTimeout(800);
       const headerVisible = await isVisibleInViewport(
         page,
         "section#definition-lists > h2"


### PR DESCRIPTION
Some of our pages are quite long. I think this scroll is not worth the "aesthetics". See https://github.com/pradyunsg/furo/discussions/384.