### PR TITLE
Use Sass-style comments in Furo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ _qiskit_furo = "qiskit_sphinx_theme"
 "Source Code" = "https://github.com/Qiskit/qiskit_sphinx_theme"
 
 [tool.sphinx-theme-builder]
-node-version = "18.16.0"
+node-version = "18.16.1"
 
 
 [tool.pytest.ini_options]

--- a/src/qiskit_sphinx_theme/assets/styles/_admonitions.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_admonitions.scss
@@ -2,9 +2,9 @@
 // (e.g. warning boxes). We don't use the Success admonition though.
 
 body {
-    /* See https://carbondesignsystem.com/guidelines/color/usage and
-    *  https://carbondesignsystem.com/components/notification/style/ for where these colors
-    *  come from. */
+    // See https://carbondesignsystem.com/guidelines/color/usage and
+    // https://carbondesignsystem.com/components/notification/style/ for where these colors
+    // come from.
     --qiskit-color-admonition-info--background: #edf5ff;
     --qiskit-color-admonition-info--border: #0043ce;
     --qiskit-color-admonition-warning--background: #fcf4d6;
@@ -18,17 +18,27 @@ body {
   border: 1px solid var(--qiskit-color-admonition-info--background);
 }
 
-/* Admonitions are complex because they use a 3px left border with a different color than the rest
-*  of the div. If we naively used `border-left`, we'd end up with a weird-looking diagonal, as
-*  described at
-*  https://stackoverflow.com/questions/18129718/weird-css-behavior-diagonal-border-why-is-the-border-edge-not-straight.
-*  So, instead, we use `.admonition:before` to set up the left border.
-*
-*  We don't specify the border colors or the `background` for `.admonition:before` because each
-*  specific admonition type will set them. We also don't set a border-top because we expect the
-*  border color to be the same as the top's background. */
+p.topic-title::before {
+  -webkit-mask-image: var(--icon-info);
+  mask-image: var(--icon-info);
+  background-color: var(--qiskit-color-admonition-info--border);
+}
+
+p.topic-title {
+  background-color: var(--qiskit-color-admonition-info--background);
+}
+
+// Admonitions are complex because they use a 3px left border with a different color than the rest
+// of the div. If we naively used `border-left`, we'd end up with a weird-looking diagonal, as
+// described at
+// https://stackoverflow.com/questions/18129718/weird-css-behavior-diagonal-border-why-is-the-border-edge-not-straight.
+// So, instead, we use `.admonition::before` to set up the left border.
+//
+// We don't specify the border colors or the `background` for `.admonition::before` because each
+// specific admonition type will set them. We also don't set a border-top because we expect the
+// border color to be the same as the top's background.
 .admonition {
-  border-left: 0;  /* Turn off Furo's border. */
+  border-left: 0;  // Turn off Furo's border.
   border-right-style: solid;
   border-right-width: 1px;
   border-bottom-style: solid;
@@ -36,7 +46,7 @@ body {
   position: relative;
   padding-left: 12px;
 }
-.admonition:before {
+.admonition::before {
   content: '';
   position: absolute;
   top: 0;
@@ -45,16 +55,16 @@ body {
   width: 3px;
 }
 
-.admonition.attention > .admonition-title:before,
-.admonition.caution > .admonition-title:before,
-.admonition.important > .admonition-title:before,
-.admonition.warning > .admonition-title:before {
-  /* Rather than using mask-image like Furo normally does, we set `content` to the SVG. This is
-  *  because Carbon requires that we have a black exclamation mark for accessibility: the
-  *  light yellow background wouldn't be distinct enough compared to the dark yellow icon. Mask
-  *  image doesn't let us set colors, only whether to use the background color of the underlying
-  *  HTML element vs. use the background color of the SVG container. So, having a black exclamation
-  *  mark would require setting the entire .admonition-title background color to black. */
+.admonition.attention > .admonition-title::before,
+.admonition.caution > .admonition-title::before,
+.admonition.important > .admonition-title::before,
+.admonition.warning > .admonition-title::before {
+  // Rather than using mask-image like Furo normally does, we set `content` to the SVG. This is
+  // because Carbon requires that we have a black exclamation mark for accessibility: the
+  // light yellow background wouldn't be distinct enough compared to the dark yellow icon. Mask
+  // image doesn't let us set colors, only whether to use the background color of the underlying
+  // HTML element vs. use the background color of the SVG container. So, having a black exclamation
+  // mark would require setting the entire .admonition-title background color to black.
   content: var(--icon-warning);
   -webkit-mask-image: unset;
   mask-image: unset;
@@ -72,15 +82,15 @@ body {
 .admonition.warning {
   border-color: var(--qiskit-color-admonition-warning--background);
 }
-.admonition.attention:before,
-.admonition.caution:before,
-.admonition.important:before,
-.admonition.warning:before {
+.admonition.attention::before,
+.admonition.caution::before,
+.admonition.important::before,
+.admonition.warning::before {
   background: var(--qiskit-color-admonition-warning--border);
 }
 
-.admonition.danger > .admonition-title:before,
-.admonition.error > .admonition-title:before {
+.admonition.danger > .admonition-title::before,
+.admonition.error > .admonition-title::before {
   -webkit-mask-image: var(--icon-failure);
   mask-image: var(--icon-failure);
   background-color: var(--qiskit-color-admonition-error--border);
@@ -93,16 +103,15 @@ body {
 .admonition.error {
   border-color: var(--qiskit-color-admonition-error--background);
 }
-.admonition.danger:before,
-.admonition.error:before {
+.admonition.danger::before,
+.admonition.error::before {
   background: var(--qiskit-color-admonition-error--border);
 }
 
-.admonition > .admonition-title:before,
-.admonition.hint > .admonition-title:before,
-.admonition.note > .admonition-title:before,
-.admonition.tip > .admonition-title:before,
-p.topic-title:before {
+.admonition > .admonition-title::before,
+.admonition.hint > .admonition-title::before,
+.admonition.note > .admonition-title::before,
+.admonition.tip > .admonition-title::before {
   -webkit-mask-image: var(--icon-info);
   mask-image: var(--icon-info);
   background-color: var(--qiskit-color-admonition-info--border);
@@ -110,8 +119,7 @@ p.topic-title:before {
 .admonition > .admonition-title,
 .admonition.hint > .admonition-title,
 .admonition.note > .admonition-title,
-.admonition.tip > .admonition-title,
-p.topic-title {
+.admonition.tip > .admonition-title {
   background-color: var(--qiskit-color-admonition-info--background);
 }
 .admonition,
@@ -120,9 +128,9 @@ p.topic-title {
 .admonition.tip {
   border-color: var(--qiskit-color-admonition-info--background);
 }
-.admonition:before,
-.admonition.hint:before,
-.admonition.note:before,
-.admonition.tip:before {
+.admonition::before,
+.admonition.hint::before,
+.admonition.note::before,
+.admonition.tip::before {
   background: var(--qiskit-color-admonition-info--border);
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_api.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_api.scss
@@ -1,47 +1,47 @@
-/* By default, Furo uses an aggressive red color for API docs. We use a more muted black and gray. */
+// By default, Furo uses an aggressive red color for API docs. We use a more muted black and gray.
 body {
   --color-api-name: var(--color-foreground-primary);
   --color-api-pre-name: var(--color-foreground-secondary);
 
 }
 
-/* Definition lists are used for sections like "Parameters", "Return type", and "Attributes"
-*  (properties of a class). */
+// Definition lists are used for sections like "Parameters", "Return type", and "Attributes"
+// (properties of a class).
 dl.py:not(.docutils) dt {
-  /* This causes the definition-term and its border-top to only take up as much space as the
-  *  content, plus padding and margins. */
+  // This causes the definition-term and its border-top to only take up as much space as the
+  // content, plus padding and margins.
   display: inline-block;
   border-top: 2px solid var(--qiskit-color-purple);
   background-color: var(--color-background-secondary);
 }
 
-/* Rules that impact the top-level entry for the code object, which e.g. has the `[source]` button. */
+// Rules that impact the top-level entry for the code object, which e.g. has the `[source]` button.
 section > dl.py:not(.docutils) > dt {
-  /* We normally want to use inline-block for definition terms so that the purple border we add on
-  *  top does not stretch across the whole screen. But, we make an exception here it will have a
-  * `[source]` button that floats to the right. The spacing of that is non-trivial and was the
-  * source of issues in Pytorch, so we stick with Furo's spacing. */
+  // We normally want to use inline-block for definition terms so that the purple border we add on
+  // top does not stretch across the whole screen. But, we make an exception here it will have a
+  // `[source]` button that floats to the right. The spacing of that is non-trivial and was the
+  // source of issues in Pytorch, so we stick with Furo's spacing.
   display: block;
-  /* Make the border less thick so its clear the top-level page header corresponds to this line. */
+  // Make the border less thick so its clear the top-level page header corresponds to this line.
   border-top-width: 1px;
   margin-bottom: 1rem;
 }
-/* It's possible to have multiple entries for the same code object, e.g. when using typing.overload.
-*  This cancels out the margin-bottom such that only the bottom-most `dt` will have a margin-bottom
-*  in effect. */
+// It's possible to have multiple entries for the same code object, e.g. when using typing.overload.
+// This cancels out the margin-bottom such that only the bottom-most `dt` will have a margin-bottom
+// in effect.
 section > dl.py:not(.docutils) > dt:not(:first-child) {
   margin-top: -1rem;
 }
 
-/* Fix some of the definition terms like "Parameters" having no padding and being in all caps.
-*
-*  Some Qiskit projects, like Experiments, use custom API sections. Those don't set the class
-* `.field-list` on the `dl`, so we change Furo's selector from `.field-list > dt` to `dl > dt`. But,
-*  to override Furo's properties we don't like, we also have to use `.field-list > dt` for some
-*  rules to win the specificity war. */
+// Fix some of the definition terms like "Parameters" having no padding and being in all caps.
+//
+// Some Qiskit projects, like Experiments, use custom API sections. Those don't set the class
+// `.field-list` on the `dl`, so we change Furo's selector from `.field-list > dt` to `dl > dt`. But,
+// to override Furo's properties we don't like, we also have to use `.field-list > dt` for some
+// rules to win the specificity war.
 dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl > dt {
   font-weight: 700;
-  /* Copied from Furo's `.sig:not(.sig-inline)` */
+  // Copied from Furo's `.sig:not(.sig-inline)`
   padding: .25rem .5rem .25rem 3em;
   text-indent: -2.5em;
 }
@@ -55,14 +55,14 @@ dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.
   border-radius: 0;
 }
 
-/* Revert Furo's special-casing of rubrics for API docs. These rubrics are used for top-level
-*  section headers like "Attributes" and "Methods". We disagree with the design in
-*  https://github.com/pradyunsg/furo/discussions/505. Instead, use the rules from `p.rubric`. */
+// Revert Furo's special-casing of rubrics for API docs. These rubrics are used for top-level
+// section headers like "Attributes" and "Methods". We disagree with the design in
+// https://github.com/pradyunsg/furo/discussions/505. Instead, use the rules from `p.rubric`.
 dl.py dd p.rubric {
   font-size: 1.125em;
   font-weight: 700;
   line-height: 1.25;
   text-transform: unset;
-  /* This is custom because Furo doesn't have enough space by default. */
+  // This is custom because Furo doesn't have enough space by default.
   margin-top: 1.25em;
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_drop-shadows.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_drop-shadows.scss
@@ -1,4 +1,6 @@
 // We use a flat design with Carbon, so disable box-shadows and rounded borders.
+//
+// `:not(#specifity-war)` is to work around specifity wars.
 
 .admonition,
 .topic,
@@ -8,8 +10,6 @@ kbd:not(.compound) {
   box-shadow: none;
 }
 
-/* We have a specificity war with Sphinx design elements. The `:not(#specifity-war)` selector
-*  works around that. */
 :not(#specifity-war).sd-card,
 :not(#specifity-war).sd-tab-content,
 :not(#specifity-war).sd-shadow-sm,

--- a/src/qiskit_sphinx_theme/assets/styles/_icons.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_icons.scss
@@ -1,14 +1,14 @@
-/* We must use Carbon for all icons: https://carbondesignsystem.com/guidelines/icons/library/.
-*  To use an icon, download it and format it to one line.
-*
-* We only override icons for what we use. Others get turned off by e.g. our "admonitions"
-* CSS rules. */
+// We must use Carbon for all icons: https://carbondesignsystem.com/guidelines/icons/library/.
+// To use an icon, download it and format it to one line.
+//
+// We only override icons for what we use. Others get turned off by e.g. our "admonitions"
+// CSS rules.
 
 body {
   --icon-search: url('data:image/svg+xml;charset=utf-8,<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><style>.cls-1 {fill: none;}</style></defs><path d="M29,27.5859l-7.5521-7.5521a11.0177,11.0177,0,1,0-1.4141,1.4141L27.5859,29ZM4,13a9,9,0,1,1,9,9A9.01,9.01,0,0,1,4,13Z" transform="translate(0 0)"/><rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/></svg>');
   --icon-info: url('data:image/svg+xml;charset=utf-8,<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><style>.cls-1 {fill: none;}</style></defs><path id="inner-path" class="cls-1" d="M16,8a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,16,8Zm4,13.875H17.125v-8H13v2.25h1.875v5.75H12v2.25h8Z" transform="translate(0 0)"/><path d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,6a1.5,1.5,0,1,1-1.5,1.5A1.5,1.5,0,0,1,16,8Zm4,16.125H12v-2.25h2.875v-5.75H13v-2.25h4.125v8H20Z" transform="translate(0 0)"/><rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/></svg>');
-  /* We manually set the CSS classes `st1` and `st2` to the colors for warnings. See the
-  *  admonitions section for an explanation of why. */
+  // We manually set the CSS classes `st1` and `st2` to the colors for warnings. See
+  // _admonitions.scss for an explanation of why.
   --icon-warning: url('data:image/svg+xml;charset=utf-8,<svg version="1.1" id="icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve"><style type="text/css">.st0{fill:none;}.st1{fill:%23f1c21b;}.st2{fill:black;}</style><rect id="Transparent_Rectangle" class="st0" width="32" height="32"/><path id="Compound_Path" class="st1" d="M16,2C8.3,2,2,8.3,2,16s6.3,14,14,14s14-6.3,14-14C30,8.3,23.7,2,16,2z M14.9,8h2.2v11h-2.2V8z M16,25c-0.8,0-1.5-0.7-1.5-1.5S15.2,22,16,22c0.8,0,1.5,0.7,1.5,1.5S16.8,25,16,25z"/><path id="inner-path" class="st2" d="M17.5,23.5c0,0.8-0.7,1.5-1.5,1.5c-0.8,0-1.5-0.7-1.5-1.5S15.2,22,16,22C16.8,22,17.5,22.7,17.5,23.5z M17.1,8h-2.2v11h2.2V8z"/></svg>');
   --icon-failure: url('data:image/svg+xml;charset=utf-8,<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><style>.cls-1 {fill: none;}</style></defs><rect id="inner-path" class="cls-1" x="14.9004" y="7.2004" width="2.1996" height="17.5994" transform="translate(-6.6275 16.0001) rotate(-45)"/><path d="M16,2A13.914,13.914,0,0,0,2,16,13.914,13.914,0,0,0,16,30,13.914,13.914,0,0,0,30,16,13.914,13.914,0,0,0,16,2Zm5.4449,21L9,10.5557,10.5557,9,23,21.4448Z"/><rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/></svg>');
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_layout.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_layout.scss
@@ -49,6 +49,6 @@ body {
 
 @media (max-width: 67em) {
   .sidebar-drawer {
-    left: calc(var(--qiskit-left-sidebar-width) // -1);
+    left: calc(var(--qiskit-left-sidebar-width) * -1);
   }
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_layout.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_layout.scss
@@ -1,50 +1,54 @@
+// By default, Furo expands the left and right sidebars when the page width increases, but it
+// doesn't increase the entry size. It also keeps the page contents fixed at 46em.
+//
+// Instead, we always keep the side bars the same size, and we expand the main page
+// contents. This is a better use of screen real estate and is more consistent with qiskit.org.
+//
+// But, we only expand the main contents up to 60em because best practices recommend not having
+// prose-heavy sites spread content over too long:
+// https://www.mediawiki.org/wiki/Reading/Web/Desktop_Improvements/Features/Limiting_content_width#Goals_and_Motivation
+// When the max-width is reached, the right page table of contents will stay in its same position and
+// whitespace will be added to the right. That is much simpler for us to implement and avoids the
+// sidebar from being split way too far from the page content itself.
+//
+// The easiest way to achieve this is using flexbox, given that Furo already uses it. We keep
+// Furo's default values for `width` and `min-width` for the .sidebar-drawer because it's necessary
+// for spacing to work properly.
+
 body {
-  /* This defaults to 15em in Furo, but we want a little bigger. */
+  // This defaults to 15em in Furo, but we want a little bigger.
   --qiskit-left-sidebar-width: 18em;
 }
 
-/* Disable Furo making the whole site larger on big screens. This results in `rem` having a
-* bigger size, so things like the Qiskit top nav bar getting bigger, which we don't like. */
+// Disable Furo making the whole site larger on big screens. This results in `rem` having a
+// bigger size, so things like the Qiskit top nav bar getting bigger, which we don't like.
 @media (min-width: 97em) {
   html {
     font-size: 100%;
   }
 }
 
-/* By default, Furo expands the left and right sidebars when the page width increases, but it
-* doesn't increase the entry size. It also keeps the page contents fixed at 46em.
-*
-* Instead, we always keep the side bars the same size, and we expand the main page
-* contents. This is a better use of screen real estate and is more consistent with qiskit.org.
-*
-* But, we only expand the main contents up to 60em because best practices recommend not having
-* prose-heavy sites spread content over too long:
-* https://www.mediawiki.org/wiki/Reading/Web/Desktop_Improvements/Features/Limiting_content_width#Goals_and_Motivation
-* When the max-width is reached, the right page table of contents will stay in its same position and
-* whitespace will be added to the right. That is much simpler for us to implement and avoids the
-* sidebar from being split way too far from the page content itself.
-*
-* The easiest way to achieve this is using flexbox, given that Furo already uses it. We keep
-* Furo's default values for `width` and `min-width` because it's necessary for spacing to work
-* properly.  */
 .sidebar-drawer {
   flex: 0 0 var(--qiskit-left-sidebar-width);
   width: var(--qiskit-left-sidebar-width);
   min-width: var(--qiskit-left-sidebar-width);
 }
+
 .sidebar-container {
   width: var(--qiskit-left-sidebar-width);
 }
+
 .content {
   flex: 1 1 46em;
   max-width: 60em;
 }
+
 .toc-drawer {
   flex: 0 0 15em;
 }
 
 @media (max-width: 67em) {
   .sidebar-drawer {
-    left: calc(var(--qiskit-left-sidebar-width) * -1);
+    left: calc(var(--qiskit-left-sidebar-width) // -1);
   }
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
@@ -1,23 +1,23 @@
-/* ------------------------------------------------------------------------------
-* Colors
-* ------------------------------------------------------------------------------- */
+// ------------------------------------------------------------------------------
+// Colors
+// ------------------------------------------------------------------------------
 
 body {
-  /* Use gray for the top-level links to be more muted. */
+  // Use gray for the top-level links to be more muted. 
   --color-sidebar-link-text--top-level: var(--color-sidebar-link-text);
-  /* Turn off gradient for hover. */
+  // Turn off gradient for hover. 
   --color-sidebar-item-background--hover: #efeff4;
 }
 
-/* Even though we override --color-sidebar-link--top-level to be a more muted look, we change
-*  the currently selected page to be purple to make it more obvious. */
+// Even though we override --color-sidebar-link--top-level to be a more muted look, we change
+// the currently selected page to be purple to make it more obvious. 
 .sidebar-tree .current-page > .reference {
   color: var(--qiskit-color-purple);
 }
 
-/* --------------------------------------------------------------------------------------
-* Common config for Translations & Previous Releases
-* -------------------------------------------------------------------------------------- */
+// --------------------------------------------------------------------------------------
+// Common config for Translations & Previous Releases
+// -------------------------------------------------------------------------------------- 
 
 .qiskit-translations-list-container,
 .qiskit-previous-releases-list-container {
@@ -28,25 +28,25 @@ body {
   display: block;
 }
 
+// Based off of `.toctree-l1 li`. 
+.qiskit-translations-header-container,
+.qiskit-previous-releases-header-container {
+  margin: 0;
+  position: relative;
+  // Normally this is set on `.sidebar-tree label`, which corresponds to
+  // `.qiskit-translations-toggle-container` and `.qiskit-previous-releases-toggle-container`.
+  // But we set it on the whole container because otherwise we get annoying browser highlighting
+  // of the text. 
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .qiskit-translations-header-container label,
 .qiskit-previous-releases-header-container label {
   cursor: pointer;
 }
 
-/* Based off of `.toctree-l1 li`. */
-.qiskit-translations-header-container,
-.qiskit-previous-releases-header-container {
-  margin: 0;
-  position: relative;
-  /* Normally this is set on `.sidebar-tree label`, which corresponds to
-  * `.qiskit-translations-toggle-container` and `.qiskit-previous-releases-toggle-container`.
-  * But we set it on the whole container because otherwise we get annoying browser highlighting
-  * of the text. */
-  -webkit-user-select: none;
-  user-select: none;
-}
-
-/* Based off of `.sidebar-tree li.has-children > reference` and `.sidebar-tree .reference`. */
+// Based off of `.sidebar-tree li.has-children > reference` and `.sidebar-tree .reference`. 
 .qiskit-translations-header-container p,
 .qiskit-previous-releases-header-container p {
   box-sizing: border-box;
@@ -60,14 +60,14 @@ body {
   padding-right: var(--sidebar-expander-width);
 }
 
-/* Based off of `.sidebar-tree .reference:hover`, but applied to the whole container rather than
-*  only the label text. */
+// Based off of `.sidebar-tree .reference:hover`, but applied to the whole container rather than
+// only the label text. 
 .qiskit-translations-header-container:hover,
 .qiskit-previous-releases-header-container:hover {
   background: var(--color-sidebar-item-background--hover);
 }
 
-/* Based off of `.sidebar-tree label`. */
+// Based off of `.sidebar-tree label`. 
 .qiskit-translations-toggle-container,
 .qiskit-previous-releases-toggle-container {
   background: var(--color-sidebar-item-expander-background);
@@ -81,7 +81,7 @@ body {
   width: var(--sidebar-expander-width);
 }
 
-/* Based off of `.toctree-checkbox`. */
+// Based off of `.toctree-checkbox`. 
 #translations-checkbox,
 #previous-releases-checkbox {
   display: none;
@@ -96,7 +96,7 @@ body {
   transform: rotate(-90deg);
 }
 
-/* Based off of `.sidebar-tree ul`. */
+// Based off of `.sidebar-tree ul`. 
 .qiskit-translations-list-container ul,
 .qiskit-previous-releases-list-container ul {
   display: flex;
@@ -107,14 +107,14 @@ body {
   padding: 0;
 }
 
-/* Based off of `.sidebar-tree li`. */
+// Based off of `.sidebar-tree li`. 
 .qiskit-translations-list-container li,
 .qiskit-previous-releases-list-container li {
   margin: 0;
   position: relative;
 }
 
-/* Based off of `.sidebar-tree .reference`. */
+// Based off of `.sidebar-tree .reference`. 
 .qiskit-translations-list-container a,
 .qiskit-previous-releases-list-container a {
   box-sizing: border-box;
@@ -127,15 +127,15 @@ body {
   width: 100%;
 }
 
-/* Based off of `.sidebar-tree .reference:hover`. */
+// Based off of `.sidebar-tree .reference:hover`. 
 .qiskit-translations-list-container a:hover,
 .qiskit-previous-releases-list-container a:hover {
   background: var(--color-sidebar-item-background--hover);
 }
 
-/* --------------------------------------------------------------------------------------
-* Translations
-* -------------------------------------------------------------------------------------- */
+// --------------------------------------------------------------------------------------
+// Translations
+// --------------------------------------------------------------------------------------
 
 .qiskit-translations-container {
   border-top: solid 2px var(--qiskit-color-purple);
@@ -145,34 +145,34 @@ body {
   padding-bottom: var(--sidebar-item-spacing-vertical);
 }
 
+.qiskit-translations-list-container a {
+  // We increase the horizontal padding for some visual distinction with the normal sidebar.
+  padding: var(--sidebar-item-spacing-vertical) calc(var(--sidebar-item-spacing-horizontal) // 1.5);
+}
+
 .qiskit-translations-toggle-container {
-  /* Unlike Furo, we set this to 100% instead of `var(--sidebar-item-height)`. */
+  // Unlike Furo, we set this to 100% instead of `var(--sidebar-item-height)`. 
   height: 100%;
 }
 
-.qiskit-translations-list-container a {
-  /* We increase the horizontal padding for some visual distinction with the normal sidebar. */
-  padding: var(--sidebar-item-spacing-vertical) calc(var(--sidebar-item-spacing-horizontal) * 1.5);
-}
+// ------------------------------------------------------------------------------
+// Previous Releases
+// ------------------------------------------------------------------------------
 
-/* ------------------------------------------------------------------------------
-* Previous Releases
-* ------------------------------------------------------------------------------- */
-
-/* Inspired by `.sidebar-tree li > ul`. */
+// Inspired by `.sidebar-tree li > ul`. 
 .qiskit-previous-releases-list-container ul {
-  margin-left: calc(var(--sidebar-item-spacing-horizontal) * 0.5);
-}
-
-/* Inspired by `.sidebar-tree`. */
-.qiskit-previous-releases-container {
-  font-size: var(--sidebar-item-font-size);
-  margin-bottom: var(--sidebar-item-spacing-vertical);
-  margin-top: 0;
+  margin-left: calc(var(--sidebar-item-spacing-horizontal) // 0.5);
 }
 
 .qiskit-previous-releases-list-container a {
   color: var(--color-sidebar-link-text);
+}
+
+// Inspired by `.sidebar-tree`. 
+.qiskit-previous-releases-container {
+  font-size: var(--sidebar-item-font-size);
+  margin-bottom: var(--sidebar-item-spacing-vertical);
+  margin-top: 0;
 }
 
 .qiskit-previous-releases-header-container p {

--- a/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
@@ -147,7 +147,7 @@ body {
 
 .qiskit-translations-list-container a {
   // We increase the horizontal padding for some visual distinction with the normal sidebar.
-  padding: var(--sidebar-item-spacing-vertical) calc(var(--sidebar-item-spacing-horizontal) // 1.5);
+  padding: var(--sidebar-item-spacing-vertical) calc(var(--sidebar-item-spacing-horizontal) * 1.5);
 }
 
 .qiskit-translations-toggle-container {
@@ -161,7 +161,7 @@ body {
 
 // Inspired by `.sidebar-tree li > ul`. 
 .qiskit-previous-releases-list-container ul {
-  margin-left: calc(var(--sidebar-item-spacing-horizontal) // 0.5);
+  margin-left: calc(var(--sidebar-item-spacing-horizontal) * 0.5);
 }
 
 .qiskit-previous-releases-list-container a {

--- a/src/qiskit_sphinx_theme/assets/styles/_sphinx-extensions.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_sphinx-extensions.scss
@@ -1,21 +1,21 @@
-/* ---------------------------------------------------------------------------
-* nbsphinx (tutorials)
-* ---------------------------------------------------------------------------- */
+// ---------------------------------------------------------------------------
+// nbsphinx (tutorials)
+// ---------------------------------------------------------------------------
 
-/* Don't have a purple border. This rule overrides `.npshinx-gallery > a`.
-*
-* We keep the default style of the text itself being purple to be consistent with the general style
-* of the site using purple for links.*/
+// Don't have a purple border. This rule overrides `.npshinx-gallery > a`.
+//
+// We keep the default style of the text itself being purple to be consistent with the general style
+// of the site using purple for links.
 .nbsphinx-gallery > a.reference {
   border: 1px dotted var(--color-foreground-secondary);
 }
 
-/* ---------------------------------------------------------------------------
-* jupyter-sphinx
-* ---------------------------------------------------------------------------- */
+// ---------------------------------------------------------------------------
+// jupyter-sphinx
+// ---------------------------------------------------------------------------
 
-/* Fix for https://github.com/Qiskit/qiskit_sphinx_theme/issues/306. Instead, use the rule from
-*  `.highlight pre, pre.literal-block`. */
+// Fix for https://github.com/Qiskit/qiskit_sphinx_theme/issues/306. Instead, use the rule from
+// `.highlight pre, pre.literal-block`.
 :not(#specifity-war).jupyter_container div.code_cell pre {
   padding: .625rem .875rem;
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_tables.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_tables.scss
@@ -1,10 +1,19 @@
 body {
-  /* Use the same table header color as qiskit.org. */
+  // Use the same table header color as qiskit.org.
   --color-table-header-background: #dde1e6;
 }
 
-/* Because we disable drop shadows, restore borders for tables by overriding rules that disabled
-*  them. */
+// Add a border to the top of the table so that tables without headers have a border.
+//
+// It's arguably not necessary to add a top border when the table has a header and we could
+// use a more precise selector `table.docutils tbody`. But, the rest of the table will already have
+// borders so we are consistent this way.
+table.docutils {
+  border-top: 1px solid var(--color-table-border);
+}
+
+// Because we disable drop shadows in _drop-shadows.scss, restore borders for tables by overriding
+// rules that disabled them.
 table.docutils td:last-child,
 table.docutils th:last-child {
   border-right: 1px solid var(--color-table-border);
@@ -14,16 +23,7 @@ table.docutils th:first-child {
   border-left: 1px solid var(--color-table-border);
 }
 
-/* Also add a border to the top of the table so that tables without headers have a border.
-*
-*  It's arguably not necessary to add a top border when the table has a header and we could
-*  use a more precise selector `table.docutils tbody`. But, the rest of the table will already have
-*  borders so we are consistent this way. */
-table.docutils {
-  border-top: 1px solid var(--color-table-border);
-}
-
-/* Turn off center aligning of tables. */
+// Turn off center aligning of tables.
 table.align-default {
   margin-left: 0;
 }

--- a/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
@@ -1,20 +1,20 @@
 body {
-  /* This value is duplicated from `top-nav-bar.js`. Its definition of the variable is not
-  * exposed globally. Keep in sync. */
+  // This value is duplicated from `top-nav-bar.js`. Its definition of the variable is not
+  // exposed globally. Keep in sync.
   --qiskit-top-nav-bar-height: 3.5rem;
 }
 
-/* Disable dark mode until qiskit.org has it: https://github.com/Qiskit/qiskit.org/issues/2310 */
+// Disable dark mode until qiskit.org has it: https://github.com/Qiskit/qiskit.org/issues/2310 */
 .theme-toggle-container {
   display: none;
 }
 
-/* Improve the custom design of the header icon in terms of its thickness. */
+// Improve the custom design of the header icon in terms of its thickness.
 div.header-left svg use {
   stroke-width: 0.5;
 }
 
-/* Fix Qiskit top nav bar hiding Furo's top nav bar and side menus. */
+// Fix Qiskit top nav bar hiding Furo's top nav bar and side menus.
 .mobile-header,
 .sidebar-sticky,
 .toc-sticky,
@@ -33,8 +33,8 @@ div.header-left svg use {
   }
 }
 
-/* These are also necessary to fix the Qiskit top nav bar hiding Furo content/menus, specifically
-*  when the user is scrolled down to the bottom of the page. They override Furo's rules. */
+// These are also necessary to fix the Qiskit top nav bar hiding Furo content/menus, specifically
+// when the user is scrolled down to the bottom of the page. They override Furo's rules.
 .sidebar-sticky,
 .toc-sticky {
   height: calc(100vh - var(--qiskit-top-nav-bar-height));
@@ -43,11 +43,11 @@ div.header-left svg use {
   max-height: calc(100vh - var(--qiskit-top-nav-bar-height));
 }
 
-/* Fix # anchor links not accounting for the top nav bar.
-*
-* The rules for mobile come from Furo, but we add --qiskit-top-nav-bar-height.
-* But for some reason, the default rule has too much spacing if we include Furo's original rule's
-* --header-height. */
+// Fix # anchor links not accounting for the top nav bar.
+//
+// The rules for mobile come from Furo, but we add --qiskit-top-nav-bar-height.
+// But for some reason, the default rule has too much spacing if we include Furo's original rule's
+// --header-height.
 :target {
   scroll-margin-top: var(--qiskit-top-nav-bar-height);
 }
@@ -55,14 +55,14 @@ div.header-left svg use {
   :target {
      scroll-margin-top: calc(0.5rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
   }
-  /* When a heading is selected */
+  // When a heading is selected.
   section > span:target {
     scroll-margin-top: calc(0.8rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
   }
 }
 
-/* Turn off highlighting of the current page until we can properly solve
-*  https://github.com/Qiskit/qiskit_sphinx_theme/issues/368. */
+// Turn off highlighting of the current page until we can properly solve
+// https://github.com/Qiskit/qiskit_sphinx_theme/issues/368.
 .toc-tree li.scroll-current > .reference {
   color: var(--color-toc-item-text);
   font-weight: unset;

--- a/src/qiskit_sphinx_theme/assets/styles/_typography.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_typography.scss
@@ -3,8 +3,8 @@ body {
   --font-stack--monospace: 'IBM Plex Mono', 'Consolas', 'Courier New', monospace;
 }
 
-/* Without this, long titles break the site. This is especially a problem in API docs.
-*  Remove if https://github.com/pradyunsg/furo/pull/670 gets merged and released. */
+// Without this, long titles break the site. This is especially a problem in API docs.
+// Remove if https://github.com/pradyunsg/furo/pull/670 gets merged and released.
 h1,
 h2,
 h3,
@@ -14,8 +14,8 @@ h6 {
   overflow-wrap: break-word;
 }
 
-/* Carbon only uses bold for the smallest headers:
-*  https://carbondesignsystem.com/guidelines/typography/type-sets/ */
+// Carbon only uses bold for the smallest headers:
+// https://carbondesignsystem.com/guidelines/typography/type-sets/
 h1,
 h2,
 h3,

--- a/src/qiskit_sphinx_theme/assets/styles/qiskit-sphinx-theme.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/qiskit-sphinx-theme.scss
@@ -16,7 +16,7 @@ body {
   --color-brand-content: var(--qiskit-color-purple);
 }
 
-/* Turn off scroll animation for anchor links: https://github.com/pradyunsg/furo/discussions/384 */
+// Turn off scroll animation for anchor links: https://github.com/pradyunsg/furo/discussions/384
 html {
   scroll-behavior: auto;
 }


### PR DESCRIPTION
CSS didn't let us use `//` style comments, but SCSS (Sassy CSS) does. These comments are simpler to write and read.

## Uses `::before` rather than `:before`

I found out that it's preferred to use `::before` for clarity, e.g. `footer::before` rather than `footer:before`.

## Moves some related rules closer together

Some code was moved closer to its relevant rules. This is prework for an upcoming refactor to use Sass nesting. 

No changes were made -- it only moves the code.