### PR TITLE
Fix disabling Furo dark mode on Safari

### DIFF
--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/base.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/base.html
@@ -90,8 +90,8 @@
   <body>
     {% block body %}
     <script>
-      {#- QISKIT CHANGE: start. Set default theme to light mode. -#}
-      document.body.dataset.theme = localStorage.getItem("theme") || "light";
+      {#- QISKIT CHANGE: start. Force light mode. -#}
+      document.body.dataset.theme = "light";
       {#- QISKIT CHANGE: end. -#}
     </script>
     {% endblock %}


### PR DESCRIPTION
https://github.com/Qiskit/qiskit_sphinx_theme/pull/437 broke Safari's dark mode. Now disabling dark mode works properly for Chrome, Firefox, and Safari.