### PR TITLE
Prep 1.13.0rc2

### DIFF
--- a/src/qiskit_sphinx_theme/__init__.py
+++ b/src/qiskit_sphinx_theme/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import sphinx.application
     import sphinx.config
 
-__version__ = "1.13.0rc1"
+__version__ = "1.13.0rc2"
 __version_full__ = __version__
 
 


### PR DESCRIPTION
While we still need to figure out https://github.com/Qiskit/qiskit_sphinx_theme/issues/328, this release candidate fixes several issues discovered in 1.13.0rc1, especially with responsiveness (mobile).