### PR TITLE
Add copyright headers along with Furo license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Copy the HTML template from Furo and save it in the same file path. Then, at the
 
 ```
 {#-
-  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+  This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license.
 
   When adding custom Qiskit code, surround it with `QISKIT CHANGE: start` and
   `QISKIT CHANGE: end` Jinja-style comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,8 +141,12 @@ We try to keep changes to a minimum because every divergence we make from base F
 Copy the HTML template from Furo and save it in the same file path. Then, at the top of the file, add this header:
 
 ```
-{#- This file is vendored from Furo. When adding custom Qiskit code, surround it with
-`QISKIT CHANGE: start` and `QISKIT CHANGE: end` Jinja-style comments. -#}
+{#-
+  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+
+  When adding custom Qiskit code, surround it with `QISKIT CHANGE: start` and
+  `QISKIT CHANGE: end` Jinja-style comments.
+-#}
 ```
 
 When making changes, use those comments to make clear where and what we changed. For example:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 # This Dockerfile is used to preview the docs in pull requests via GitHub Actions.
 #
 # To test it out locally:

--- a/LICENSE
+++ b/LICENSE
@@ -224,3 +224,26 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+The MIT License (MIT)
+
+Copyright (c) 2020 Pradyun Gedam <mail@pradyunsg.me>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 import { defineConfig } from "@playwright/test";
 
 const baseURL = "http://127.0.0.1:8080";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qiskit-sphinx-theme"
 description = "A Sphinx theme for Qiskit and Qiskit Ecosystem projects"
 dynamic = ["version"]
 
-license = { text = "Apache 2" }
+license = { file = "LICENSE" }
 authors = [{ name = "Qiskit Development Team", email = "hello@qiskit.org" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/qiskit_sphinx_theme/assets/scripts/gumshoe-patched.js
+++ b/src/qiskit_sphinx_theme/assets/scripts/gumshoe-patched.js
@@ -1,4 +1,4 @@
-// Vendored exactly from Furo's `assets/scripts/gumshoe-patched.js`.
+/*! This file is vendored from Furo by Pradyun Gedam, used under the MIT license. */
 /*!
  * gumshoejs v5.1.2 (patched by @pradyunsg)
  * A simple, framework-agnostic scrollspy script.

--- a/src/qiskit_sphinx_theme/assets/scripts/gumshoe-patched.js
+++ b/src/qiskit_sphinx_theme/assets/scripts/gumshoe-patched.js
@@ -1,4 +1,4 @@
-/*! This file is vendored from Furo by Pradyun Gedam, used under the MIT license. */
+/*! This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license. */
 /*!
  * gumshoejs v5.1.2 (patched by @pradyunsg)
  * A simple, framework-agnostic scrollspy script.

--- a/src/qiskit_sphinx_theme/assets/scripts/qiskit-sphinx-theme.js
+++ b/src/qiskit_sphinx_theme/assets/scripts/qiskit-sphinx-theme.js
@@ -1,4 +1,4 @@
-/*! This file is vendored from Furo by Pradyun Gedam, used under the MIT license. */
+/*! This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license. */
 // When making changes, surround it with `QISKIT CHANGE: start` and `QISKIT CHANGE: end` comments.
 
 import Gumshoe from "./gumshoe-patched.js";

--- a/src/qiskit_sphinx_theme/assets/scripts/qiskit-sphinx-theme.js
+++ b/src/qiskit_sphinx_theme/assets/scripts/qiskit-sphinx-theme.js
@@ -1,5 +1,5 @@
-// This file is vendored from Furo's `assets/scripts/furo.js`. When adding custom Qiskit code,
-// surround it with `QISKIT CHANGE: start` and `QISKIT CHANGE: end` comments.
+/*! This file is vendored from Furo by Pradyun Gedam, used under the MIT license. */
+// When making changes, surround it with `QISKIT CHANGE: start` and `QISKIT CHANGE: end` comments.
 
 import Gumshoe from "./gumshoe-patched.js";
 

--- a/src/qiskit_sphinx_theme/assets/styles/_admonitions.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_admonitions.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // We use https://carbondesignsystem.com/components/notification/style/ for admonitions
 // (e.g. warning boxes. We don't use the Success admonition though.
 

--- a/src/qiskit_sphinx_theme/assets/styles/_api.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_api.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // By default, Furo uses an aggressive red color for API docs. We use a more muted black and gray.
 body {
   --color-api-name: var(--color-foreground-primary);

--- a/src/qiskit_sphinx_theme/assets/styles/_custom-directives.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_custom-directives.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // This creates a purple border at the bottom. We set the width to 0. The relevant rule
 // should change the width to 100% on hover so that it transitions in.
 @mixin purple-underline {

--- a/src/qiskit_sphinx_theme/assets/styles/_drop-shadows.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_drop-shadows.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // We use a flat design with Carbon, so disable box-shadows and rounded borders.
 //
 // `:not(#specifity-war)` is to work around specifity wars.

--- a/src/qiskit_sphinx_theme/assets/styles/_footer.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_footer.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 .qiskit-analytics-container {
   display: inline-flex;
   border-top: 1px solid var(--color-background-border);

--- a/src/qiskit_sphinx_theme/assets/styles/_icons.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_icons.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // We must use Carbon for all icons: https://carbondesignsystem.com/guidelines/icons/library/.
 // To use an icon, download it and format it to one line.
 //

--- a/src/qiskit_sphinx_theme/assets/styles/_layout.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_layout.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // By default, Furo expands the left and right sidebars when the page width increases, but it
 // doesn't increase the entry size. It also keeps the page contents fixed at 46em.
 //

--- a/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // ------------------------------------------------------------------------------
 // Colors
 // ------------------------------------------------------------------------------

--- a/src/qiskit_sphinx_theme/assets/styles/_sphinx-extensions.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_sphinx-extensions.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // ---------------------------------------------------------------------------
 // nbsphinx (tutorials)
 // ---------------------------------------------------------------------------

--- a/src/qiskit_sphinx_theme/assets/styles/_tables.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_tables.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 body {
   // Use the same table header color as qiskit.org.
   --color-table-header-background: #dde1e6;

--- a/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 // This value is duplicated from `top-nav-bar.js`. Its definition of the variable is not
 // exposed globally. Keep in sync.
 //

--- a/src/qiskit_sphinx_theme/assets/styles/_typography.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_typography.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 body {
   --font-stack: 'IBM Plex Sans', 'Roboto', 'Helvetica Neue', 'Arial', sans-serif;
   --font-stack--monospace: 'IBM Plex Mono', 'Consolas', 'Courier New', monospace;

--- a/src/qiskit_sphinx_theme/assets/styles/qiskit-sphinx-theme.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/qiskit-sphinx-theme.scss
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 @import "admonitions";
 @import "api";
 @import "custom-directives";

--- a/src/qiskit_sphinx_theme/pytorch/breadcrumbs.html
+++ b/src/qiskit_sphinx_theme/pytorch/breadcrumbs.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="pytorch-breadcrumbs">

--- a/src/qiskit_sphinx_theme/pytorch/footer.html
+++ b/src/qiskit_sphinx_theme/pytorch/footer.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 <footer>
 <!-- USER FEEDBACK -->
   {% if analytics_enabled %}

--- a/src/qiskit_sphinx_theme/pytorch/languages.html
+++ b/src/qiskit_sphinx_theme/pytorch/languages.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 {% if translations_list %}
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">

--- a/src/qiskit_sphinx_theme/pytorch/layout.html
+++ b/src/qiskit_sphinx_theme/pytorch/layout.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 {# Sphinx template variable setup #}
 {%- if not embedded and docstitle %}
   {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}

--- a/src/qiskit_sphinx_theme/pytorch/search.html
+++ b/src/qiskit_sphinx_theme/pytorch/search.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 {#
     basic/search.html
     ~~~~~~~~~~~~~~~~~

--- a/src/qiskit_sphinx_theme/pytorch/searchbox.html
+++ b/src/qiskit_sphinx_theme/pytorch/searchbox.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 <div role="search">
   <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
     <input type="text" name="q" placeholder="Search {{ project }} Docs" />

--- a/src/qiskit_sphinx_theme/pytorch/sidebar.html
+++ b/src/qiskit_sphinx_theme/pytorch/sidebar.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 <nav data-toggle="wy-nav-shift" class="pytorch-left-menu" id="pytorch-left-menu">
     <div class="pytorch-menu pytorch-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
       <div class="sidebar">

--- a/src/qiskit_sphinx_theme/pytorch/static/css/theme.css
+++ b/src/qiskit_sphinx_theme/pytorch/static/css/theme.css
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 @charset "UTF-8";
 
 /* Import IBM Plex Sans and IBM Plex Mono, at regular 400 and bold 700, italics for both. For

--- a/src/qiskit_sphinx_theme/pytorch/static/js/theme.js
+++ b/src/qiskit_sphinx_theme/pytorch/static/js/theme.js
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 derlinkrequire=(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 window.utilities = {
   scrollTop: function() {

--- a/src/qiskit_sphinx_theme/pytorch/theme.conf
+++ b/src/qiskit_sphinx_theme/pytorch/theme.conf
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 [theme]
 inherit = basic
 stylesheet = css/theme.css

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/base.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/base.html
@@ -1,5 +1,10 @@
-{#- This file is vendored from Furo. When adding custom Qiskit code, surround it with
-`QISKIT CHANGE: start` and `QISKIT CHANGE: end` Jinja-style comments. -#}
+{#-
+  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+
+  When adding custom Qiskit code, surround it with `QISKIT CHANGE: start` and
+  `QISKIT CHANGE: end` Jinja-style comments.
+-#}
+
 <!doctype html>
 <html class="no-js"{% if language is not none %} lang="{{ language }}"{% endif %}>
   <head>

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/base.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/base.html
@@ -1,5 +1,5 @@
 {#-
-  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+  This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license.
 
   When adding custom Qiskit code, surround it with `QISKIT CHANGE: start` and
   `QISKIT CHANGE: end` Jinja-style comments.

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/extra_head.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/extra_head.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 {#- Per https://carbondesignsystem.com/guidelines/typography/overview, this loads these fonts with

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/footer_analytics.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/footer_analytics.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 {% if analytics_enabled %}
   <script>
     function userFeedbackClicked(ctaType) {

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_languages.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_languages.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 {% if translations_list %}
 {#- The HTML and CSS structure is inspired by Furo's left sidebar's table of contents for a
  top-level page with subpages. It has a similar setup to us: a text label and chevron icon to

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_version_list.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_version_list.html
@@ -1,3 +1,17 @@
+{#-
+  This code is part of Qiskit.
+
+  (C) Copyright IBM 2023.
+
+  This code is licensed under the Apache License, Version 2.0. You may
+  obtain a copy of this license in the LICENSE.txt file in the root directory
+  of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+  Any modifications or derivative works of this code must retain this
+  copyright notice, and modified files need to carry a notice indicating
+  that they have been altered from the originals.
+-#}
+
 {% if version_list %}
 {#- The HTML and CSS structure is inspired by Furo's left sidebar's table of contents for a
  top-level page with subpages, but with the text looking like a sidebar caption. It has a

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/page.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/page.html
@@ -1,5 +1,10 @@
-{#- This file is vendored from Furo. When adding custom Qiskit code, surround it with
-`QISKIT CHANGE: start` and `QISKIT CHANGE: end` Jinja-style comments. -#}
+{#-
+  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+
+  When adding custom Qiskit code, surround it with `QISKIT CHANGE: start` and
+  `QISKIT CHANGE: end` Jinja-style comments.
+-#}
+
 {% extends "base.html" %}
 
 {% block body -%}

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/page.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/page.html
@@ -1,5 +1,5 @@
 {#-
-  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+  This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license.
 
   When adding custom Qiskit code, surround it with `QISKIT CHANGE: start` and
   `QISKIT CHANGE: end` Jinja-style comments.

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/partials/icons.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/partials/icons.html
@@ -1,12 +1,15 @@
-{#- This file is originally vendored from Furo, but we've made substantial changes to comply with
-IBM Carbon requirements (https://carbondesignsystem.com/guidelines/icons/library/):
+{#-
+  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
 
-  * svg-menu removed
-  * svg-toc replaced with Carbon
-  * svg-arrow-right replaced with Carbon
+  We've made substantial changes to comply with IBM Carbon requirements
+  (https://carbondesignsystem.com/guidelines/icons/library/):
 
-We keep the icons for sun, moon, and sun-half but only because we disabled dark mode, so it's
-irrelevant.
+    * svg-menu removed
+    * svg-toc replaced with Carbon
+    * svg-arrow-right replaced with Carbon
+
+  We keep the icons for sun, moon, and sun-half but only because we disabled dark mode, so it's
+  irrelevant.
 -#}
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
   <symbol id="svg-toc" viewBox="0 0 24 24">

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/partials/icons.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/partials/icons.html
@@ -1,5 +1,5 @@
 {#-
-  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+  This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license.
 
   We've made substantial changes to comply with IBM Carbon requirements
   (https://carbondesignsystem.com/guidelines/icons/library/):

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/sidebar/search.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/sidebar/search.html
@@ -1,5 +1,10 @@
-{#- This file is vendored from Furo's sidebars/search.html. Its only change is to the `placeholder`
-for the search `input` element to include the project name. -#}
+{#-
+  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+
+  Its only change is to the `placeholder` for the search `input` element to include the
+  project name.
+-#}
+
 <form class="sidebar-search-container" method="get" action="{{ pathto('search') }}" role="search">
   <input class="sidebar-search" placeholder="Search {{ project }} docs" name="q" aria-label="{{ _("Search" ) }}">
   <input type="hidden" name="check_keywords" value="yes">

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/sidebar/search.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/sidebar/search.html
@@ -1,5 +1,5 @@
 {#-
-  This file is vendored from Furo by Pradyun Gedam, used under the MIT license.
+  This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license.
 
   Its only change is to the `placeholder` for the search `input` element to include the
   project name.

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/theme.conf
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/theme.conf
@@ -1,9 +1,21 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 [theme]
 inherit = furo
 stylesheet = styles/qiskit-sphinx-theme.css
 
 sidebars =
-  custom_templates/sidebar_search.html,
+  sidebar/search.html,
   sidebar/scroll-start.html,
   sidebar/navigation.html,
   custom_templates/sidebar_version_list.html,

--- a/tests/js/Dockerfile
+++ b/tests/js/Dockerfile
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 # A dockerfile to run our snapshot tests locally. This is to avoid issues with CI and local
 # differing. In CI, we also run with the same base image.
 # See https://playwright.dev/docs/test-snapshots.

--- a/tests/js/snapshots.test.js
+++ b/tests/js/snapshots.test.js
@@ -1,3 +1,16 @@
+/* This code is part of Qiskit.
+ *
+ * (C) Copyright IBM 2023.
+ *
+ * This code is licensed under the Apache License, Version 2.0. You may
+ * obtain a copy of this license in the LICENSE.txt file in the root directory
+ * of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Any modifications or derivative works of this code must retain this
+ * copyright notice, and modified files need to carry a notice indicating
+ * that they have been altered from the originals.
+ */
+
 import { expect, test } from "@playwright/test";
 
 // -----------------------------------------------------------------------

--- a/tests/py/previous_releases_test.py
+++ b/tests/py/previous_releases_test.py
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/py/translations_test.py
+++ b/tests/py/translations_test.py
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/py/web_components_test.py
+++ b/tests/py/web_components_test.py
@@ -1,3 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """Check that our vendored web components are identical between the different themes."""
 
 from pathlib import Path


### PR DESCRIPTION
## Adds Furo license

It's extra safe to do this because we vendor about 6 files from Furo. 

We use the prior art of Pytorch of including the license directly in `LICENSE` at the bottom. Pytorch is also an MIT license and we substantially vendored it, so it's a similar setup.

## Fixes LICENSE inclusion

The switch to `pyproject.toml` accidentally changed us including the LICENSE file to instead have the text `Apache 2`.

## Adds copyright file headers

We should have been doing this from the start because Qiskit projects are expected to put copyright headers on every file. This becomes especially useful if we more substantially vendor Furo code in https://github.com/Qiskit/qiskit_sphinx_theme/pull/463 to make clear what is what.

All files that are originally written by Qiskit contributors use the standard Apache 2 license we already use in this project.

Meanwhile, files that are vendored from Furo now use this standard notice:

> This file is vendored from Furo (created by Pradyun Gedam) and used under the MIT license.

Even though the MIT license does not require file headers, and Furo itself does not use it, it is a good practice to make clear what originally comes from Furo.

## Also renames `search_sidebar.html`

This file is vendored from Furo, but we had it under `custom_templates/search_sidebar.html` rather than the original `sidebar/search.html`. This PR renames the file so that we more properly attribute Furo and the MIT license.