### PR TITLE
Allow hiding Qiskit top nav bar in Furo (Cherry-pick of #468)

### DIFF
--- a/src/qiskit_sphinx_theme/assets/scripts/qiskit-sphinx-theme.js
+++ b/src/qiskit_sphinx_theme/assets/scripts/qiskit-sphinx-theme.js
@@ -144,9 +144,13 @@ function setupScrollSpy() {
     navClass: "scroll-current",
     offset: () => {
       let rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
-      // QISKIT CHANGE: start. Add 3.5rem for the Qiskit top nav bar.
+      // QISKIT CHANGE: start. Add 3.5rem for the Qiskit top nav bar, if visible.
       // See _top-nav-bar.scss for where the value comes from.
-      return header.getBoundingClientRect().height + (0.5 * rem) + 1 + (3.5 * rem);
+      const topNavBar = document.querySelector('qiskit-ui-shell');
+      const topNavBarHeight = (topNavBar && getComputedStyle(topNavBar).display !== 'none')
+        ? 3.5 * rem
+        : 0;
+      return header.getBoundingClientRect().height + (0.5 * rem) + 1 + topNavBarHeight;
       // QISKIT CHANGE: end.
     },
   });

--- a/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
@@ -16,7 +16,11 @@
 //
 // Also keep in sync with `qiskit-sphinx-theme.js`, which adds the top nav bar
 // in the function `setupScrollSpy`.
-$top-nav-bar-height: 3.5rem;
+//
+// We use a CSS variable so that the ecosystem theme can modify the value.
+body {
+  --qiskit-top-nav-bar-height: 3.5rem;
+}
 
 // Disable dark mode until qiskit.org has it: https://github.com/Qiskit/qiskit.org/issues/2310
 .theme-toggle-container {
@@ -34,16 +38,16 @@ div.header-left svg use {
 .toc-sticky,
 #__navigation:checked ~ .page .sidebar-drawer,
 #__toc:checked ~ .page .toc-drawer {
-  top: $top-nav-bar-height;
+  top: var(--qiskit-top-nav-bar-height);
 }
 @media (max-width: 67em) {
   .sidebar-drawer {
-    top: $top-nav-bar-height;
+    top: var(--qiskit-top-nav-bar-height);
   }
 }
 @media (max-width: 82em) {
   .toc-drawer {
-    top: $top-nav-bar-height;
+    top: var(--qiskit-top-nav-bar-height);
   }
 }
 
@@ -51,10 +55,10 @@ div.header-left svg use {
 // when the user is scrolled down to the bottom of the page. They override Furo's rules.
 .sidebar-sticky,
 .toc-sticky {
-  height: calc(100vh - $top-nav-bar-height);
+  height: calc(100vh - var(--qiskit-top-nav-bar-height));
 }
 .toc-scroll {
-  max-height: calc(100vh - $top-nav-bar-height);
+  max-height: calc(100vh - var(--qiskit-top-nav-bar-height));
 }
 
 // Fix # anchor links not accounting for the top nav bar.
@@ -63,14 +67,14 @@ div.header-left svg use {
 // But for some reason, the default rule has too much spacing if we include Furo's original rule's
 // --header-height.
 :target {
-  scroll-margin-top: $top-nav-bar-height;
+  scroll-margin-top: var(--qiskit-top-nav-bar-height);
 }
 @media (max-width: 67em) {
   :target {
-     scroll-margin-top: calc(0.5rem + var(--header-height) + $top-nav-bar-height);
+     scroll-margin-top: calc(0.5rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
   }
   // When a heading is selected.
   section > span:target {
-    scroll-margin-top: calc(0.8rem + var(--header-height) + $top-nav-bar-height);
+    scroll-margin-top: calc(0.8rem + var(--header-height) + var(--qiskit-top-nav-bar-height));
   }
 }


### PR DESCRIPTION
Unblocks https://github.com/Qiskit/qiskit_sphinx_theme/issues/465.

This allows turning off the top nav bar with simply this CSS:

```css
body {
  --qiskit-top-nav-bar-height: 0;
}

qiskit-ui-shell {
  display: none;
}
```

We'll correctly turn off all the height adjustments we had to make in `_top-nav-bar.scss` and `qiskit-sphinx-theme.js` with that config.

--

We'll use this CSS code in the Ecosystem theme, and we know Rustworkx will also want to use this code manually when adopting qiskit-sphinx-theme 1.13.