### PR TITLE
Update copyright file headers to use new language 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/docs_guide/intro/new_doc_project.rst
+++ b/docs_guide/intro/new_doc_project.rst
@@ -463,7 +463,7 @@ So the ``tools/ignore_untagged_notes.sh`` file will look like this:
 
     #!/bin/bash
 
-    # This code is part of Qiskit.
+    # This code is a Qiskit project.
     #
     # (C) Copyright IBM 20XX.
     #
@@ -572,7 +572,7 @@ The full ``tools/deploy_documentation.sh`` should then look like this:
 
     #!/bin/bash
 
-    # This code is part of Qiskit.
+    # This code is a Qiskit project.
     #
     # (C) Copyright IBM 20XX.
     #
@@ -636,7 +636,7 @@ The complete ``.github/workflows/deploy-docs.yml`` is then:
 
 .. code-block:: yaml
 
-    # This code is part of Qiskit.
+    # This code is a Qiskit project.
     #
     # (C) Copyright IBM 20XX.
     #

--- a/example_docs/docs/conf.py
+++ b/example_docs/docs/conf.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2023.
 #

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/__init__.py
+++ b/src/qiskit_sphinx_theme/__init__.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2023.
 #

--- a/src/qiskit_sphinx_theme/assets/styles/_admonitions.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_admonitions.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_api.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_api.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_custom-directives.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_custom-directives.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_drop-shadows.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_drop-shadows.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_footer.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_footer.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_icons.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_icons.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_layout.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_layout.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_left-sidebar.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_sphinx-extensions.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_sphinx-extensions.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_tables.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_tables.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_top-nav-bar.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/_typography.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_typography.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/assets/styles/qiskit-sphinx-theme.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/qiskit-sphinx-theme.scss
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/directives.py
+++ b/src/qiskit_sphinx_theme/directives.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/src/qiskit_sphinx_theme/previous_releases.py
+++ b/src/qiskit_sphinx_theme/previous_releases.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/src/qiskit_sphinx_theme/pytorch/breadcrumbs.html
+++ b/src/qiskit_sphinx_theme/pytorch/breadcrumbs.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/footer.html
+++ b/src/qiskit_sphinx_theme/pytorch/footer.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/languages.html
+++ b/src/qiskit_sphinx_theme/pytorch/languages.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/layout.html
+++ b/src/qiskit_sphinx_theme/pytorch/layout.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/search.html
+++ b/src/qiskit_sphinx_theme/pytorch/search.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/searchbox.html
+++ b/src/qiskit_sphinx_theme/pytorch/searchbox.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/sidebar.html
+++ b/src/qiskit_sphinx_theme/pytorch/sidebar.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+    This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/pytorch/static/css/theme.css
+++ b/src/qiskit_sphinx_theme/pytorch/static/css/theme.css
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/pytorch/static/js/theme.js
+++ b/src/qiskit_sphinx_theme/pytorch/static/js/theme.js
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/src/qiskit_sphinx_theme/pytorch/theme.conf
+++ b/src/qiskit_sphinx_theme/pytorch/theme.conf
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project
 #
 # (C) Copyright IBM 2023.
 #

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/extra_head.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/extra_head.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/footer_analytics.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/footer_analytics.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_languages.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_languages.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+  This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_version_list.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_version_list.html
@@ -1,5 +1,5 @@
 {#-
-  This code is part of Qiskit.
+    This code is a Qiskit project.
 
   (C) Copyright IBM 2023.
 

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/theme.conf
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/theme.conf
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/src/qiskit_sphinx_theme/translations.py
+++ b/src/qiskit_sphinx_theme/translations.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2023.
 #

--- a/tests/js/Dockerfile
+++ b/tests/js/Dockerfile
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/tests/js/qiskit.test.js
+++ b/tests/js/qiskit.test.js
@@ -1,4 +1,4 @@
-/* This code is part of Qiskit.
+/* This code is a Qiskit project.
  *
  * (C) Copyright IBM 2023.
  *

--- a/tests/py/previous_releases_test.py
+++ b/tests/py/previous_releases_test.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/tests/py/translations_test.py
+++ b/tests/py/translations_test.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #

--- a/tests/py/web_components_test.py
+++ b/tests/py/web_components_test.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is a Qiskit project.
 #
 # (C) Copyright IBM 2023.
 #


### PR DESCRIPTION
Following the suggestion shown in issue https://github.com/Qiskit/qiskit_sphinx_theme/issues/475  we changed the text from 'This code is part of Qiskit' to 'This code is a Qiskit project'.