### PR TITLE
Prepare 1.13.0

### DIFF
--- a/src/qiskit_sphinx_theme/__init__.py
+++ b/src/qiskit_sphinx_theme/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import sphinx.application
     import sphinx.config
 
-__version__ = "1.13.0rc2"
+__version__ = "1.13.0"
 __version_full__ = __version__
 
 


### PR DESCRIPTION
Three projects are now using the new theme in production:

- https://qiskit.github.io/qiskit_sphinx_theme/
- https://qiskit-extensions.github.io/circuit-knitting-toolbox/
- https://qiskit-extensions.github.io/quantum-serverless/

Rustworkx is ready to switch after landing a PR to reorganize their docs.

While some projects will still need to reorganize their API docs to be able to switch to the new theme, there are no changes we expect necessary to qiskit-sphinx-theme itself. They can speed up prod builds by reorganizing their API docs, and they can speed up their dev builds even more by using `sphinx-remove-toctrees`. 

If these approaches prove not feasible for the slow docs build, then we can do a qiskit-sphinx-theme 1.14 release with changes to qiskit-sphinx-theme. We are not yet deleting the Pytorch theme. In the meantime, other projects can start switching now.