### PR TITLE
Allow live previews of ecosystem theme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,13 @@ We upload the docs builds to CI. So, you can download what the site will look li
 3. Under the "Artifacts" section, there should be a "html_docs" entry. Download it.
 4. Choose the theme you want, such as `qiskit_html_docs.tar.gz`, and un-tar it. Then, open the `index.html` page in a browser.
 
-Contributors with write access can also use live previews of the docs: GitHub will deploy a website using your changes. To use live previews, push your branch to `upstream` rather than your fork. GitHub will leave a comment with the link to the site. Please prefix your branch name with your initials, e.g. `EA/add-translations`, for good Git hygiene.
+### Live docs preview
+
+Contributors with write access can also use live previews of the docs: GitHub will deploy a website using your changes.
+
+To use live previews, push your branch to `upstream` rather than your fork. GitHub will leave a comment with the link to the site. Please prefix your branch name with your initials, e.g. `EA/add-translations`, for good Git hygiene.
+
+If you want a live preview of the Ecosystem theme rather than the normal Qiskit theme, read the comments in the root level `Dockerfile` to change which line of code is commented out. Be careful to revert your change to the `Dockerfile` before merging the PR.
 
 ------
 ## FYI: How Furo Theme Inheritance Works

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ EXPOSE 8000
 #
 # Before merging your PR, be sure to revert the change; the `main` branch should
 # use `_qiskit_build`.
-# CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_qiskit_build"]
-CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_ecosystem_build"]
+CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_qiskit_build"]
+# CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_ecosystem_build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ EXPOSE 8000
 #
 # Before merging your PR, be sure to revert the change; the `main` branch should
 # use `_qiskit_build`.
-CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_qiskit_build"]
-# CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_ecosystem_build"]
+# CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_qiskit_build"]
+CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_ecosystem_build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,14 @@ WORKDIR /app
 COPY . .
 
 RUN tox run -e qiskit
+RUN tox run -e ecosystem
 
 EXPOSE 8000
+
+# To preview the ecosystem theme in your PR, switch which line is commented out
+# so that `_ecosystem_build` is used rather than `_qiskit_build`.
+#
+# Before merging your PR, be sure to revert the change; the `main` branch should
+# use `_qiskit_build`.
 CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_qiskit_build"]
+# CMD ["python", "-m", "http.server", "-d", "example_docs/docs/_ecosystem_build"]


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/348.

Our live preview mechanism only allows one site per deployment. It would be highly involved to try to have it deploy two sites simultaneously, both the Ecosystem and Qiskit themes.

It seems "fine enough" to only have one live preview at a time because our PRs only focus on changing one theme at a time. If we need to see how it impacts both, we can either:

* Rely on the artifact upload from CI, or
* Run CI twice so we have two previews

The default theme will always be the Qiskit theme, since that is where 90% of our custom styling code lives. Then, in your PR, you can temporarily toggle a line in the `Dockerfile` to have the Ecosystem theme build. 

I considered something more "elegant" like having you set a GitHub label on the PR, but it seemed way too complex -- the preview GitHub Action doesn't support dynamically setting values like setting environment variables.

This isn't the most "elegant" solution, but it's simple and gets the job done.