### PR TITLE
Fix docs guide broken link

### DIFF
--- a/docs_guide/tutorials/tutorials_examples.rst
+++ b/docs_guide/tutorials/tutorials_examples.rst
@@ -10,4 +10,4 @@ Qiskit IBM Runtime
 
 * :doc:`qiskit-ibm-runtime:tutorials/grover_with_sampler`
 * :doc:`qiskit-ibm-runtime:tutorials/chsh_with_estimator`
-* :doc:`qiskit-ibm-runtime:tutorials/qpe_with_sampler`
+* :doc:`qiskit-ibm-runtime:tutorials/vqe_with_estimator`


### PR DESCRIPTION
`qpe_with_sampler` no longer is published, so it results in the docs guide failing to build.