### PR TITLE
Fix Pytorch theme not activating jQuery (Cherry-pick of #497)

### DIFF
--- a/src/qiskit_sphinx_theme/__init__.py
+++ b/src/qiskit_sphinx_theme/__init__.py
@@ -67,15 +67,12 @@ def remove_thebe_if_not_needed(
     ]
 
 
-def activate_themes(app: sphinx.application.Sphinx, config: sphinx.config.Config) -> None:
-    if config.html_theme == "qiskit":
-        # We set a low priority so that our Qiskit CSS file overrides Furo.
-        app.add_css_file("styles/furo.css", 100)
-        app.add_js_file("scripts/qiskit-sphinx-theme.js")
-    else:
-        # Sphinx 6 stopped including jQuery by default. Our Pytorch theme depend on jQuery,
-        # so activate it for our users automatically.
-        app.setup_extension("sphinxcontrib.jquery")
+def activate_furo(app: sphinx.application.Sphinx, config: sphinx.config.Config) -> None:
+    if config.html_theme == "qiskit_sphinx_theme":
+        return
+    # We set a low priority so that our Qiskit CSS file overrides Furo.
+    app.add_css_file("styles/furo.css", 100)
+    app.add_js_file("scripts/qiskit-sphinx-theme.js")
 
 
 def remove_furo_js(
@@ -95,6 +92,11 @@ def setup(app: sphinx.application.Sphinx) -> dict[str, bool]:
     # Used to generate URL references. Expected to be e.g. `ecosystem/finance`.
     app.add_config_value("docs_url_prefix", default=None, rebuild="html", types=[str])
 
+    # Sphinx 6 stopped including jQuery by default. Our Pytorch theme depend on jQuery,
+    # so activate it for our users automatically. Unfortunately, we can't make this activation
+    # conditional based on which theme is chosen.
+    app.setup_extension("sphinxcontrib.jquery")
+
     # We always activate these plugins, but they are only used when users:
     # * use the directives in their RST,
     # * set `translations_list` in conf.py, or
@@ -106,7 +108,7 @@ def setup(app: sphinx.application.Sphinx) -> dict[str, bool]:
     app.add_html_theme("qiskit_sphinx_theme", _get_theme_absolute_path("pytorch"))
     app.add_html_theme("qiskit", _get_theme_absolute_path("theme/qiskit-sphinx-theme"))
 
-    app.connect("config-inited", activate_themes)
+    app.connect("config-inited", activate_furo)
     app.connect("html-page-context", remove_furo_js, priority=600)
     app.connect("html-page-context", remove_thebe_if_not_needed)
 


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/496.

https://github.com/Qiskit/qiskit_sphinx_theme/pull/419 accidentally broke Pytorch because it apparently doesn't work to call `app.setup_extension` inside the `config-inited` event. So, we were no longer activating jQuery by default.