### PR TITLE
Bump version to 1.15.0

### DIFF
--- a/src/qiskit_sphinx_theme/__init__.py
+++ b/src/qiskit_sphinx_theme/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import sphinx.application
     import sphinx.config
 
-__version__ = "1.14.1rc1"
+__version__ = "1.15.1rc1"
 __version_full__ = __version__
 
 

--- a/src/qiskit_sphinx_theme/__init__.py
+++ b/src/qiskit_sphinx_theme/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import sphinx.application
     import sphinx.config
 
-__version__ = "1.15.1rc1"
+__version__ = "1.15.0"
 __version_full__ = __version__
 
 


### PR DESCRIPTION
Note that the 1.14.1rc1 release was yanked because it was accidentally done on the `main` branch rather than `1.14` branch.

Normally we'd do 1.15.0rc1, but we go straight to 1.15.0 since we already did 1.14.1rc1 and it was fine.