### PR TITLE
Pin Sphinx to <7.2 to hotfix breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,10 @@ classifiers = [
 
 dependencies = [
     "docutils",
-    # Keep in sync with Furo's constraint.
-    "sphinx>=6.0",
+    # Keep in sync with Furo's constraint. <7.2 is to work
+    # around https://github.com/sphinx-doc/sphinx/issues/11608
+    # and https://github.com/pradyunsg/furo/discussions/693.
+    "sphinx>=6.0,<7.2",
     # Remove jQuery once we get rid of the Pytorch theme.
     "sphinxcontrib-jquery",
     # See CONTRIBUTING.md for how to upgrade Furo.


### PR DESCRIPTION
This works around https://github.com/sphinx-doc/sphinx/issues/11608 and https://github.com/pradyunsg/furo/discussions/693.

All the repos I've seen have an unbound pin on Sphinx like `>=6.0`, but a bound pin on `qiskit-sphinx-theme` like `~=1.14.0`. That means that when we release this hotfix, pip will merge the constraint from their `requirements.txt` of `>=6.0` with our theme's constraint of `>=6.0,<7.2` to use `<7.2`.

This approach allows us to easily fix all the Ecosystem projects without needing to open a new PR for each of them. They will simply rebuild their docs and use the newest patch version of `qiskit-sphinx-theme`.