### PR TITLE
Turn off CI for pushes

### DIFF
--- a/.github/workflows/docs-guide-test.yml
+++ b/.github/workflows/docs-guide-test.yml
@@ -1,10 +1,5 @@
 name: Test Docs Guide
-on:
-  push:
-    branches:
-      - main
-      - '1.*'
-  pull_request:
+on: [pull_request]
 
 permissions:
   contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,5 @@
 name: Tests
-on:
-  push:
-    branches:
-      - main
-      - '1.*'
-  pull_request:
+on: [pull_request]
 jobs:
   docs:
     name: Sample Docs Build


### PR DESCRIPTION
We use GitHub branch protection to require opening a PR for `main` and the `1.*` branches; you cannot push directly.  For `main`, we also require that CI runs against the latest `main`.

So, there is no need to run CI again for pushes since it already runs with PRs. Don't waste compute resources, which have a real environmental cost.