### PR TITLE
Fix Qiskit 1.0 release and remove references to qiskit.org

### DIFF
--- a/docs_guide/conf.py
+++ b/docs_guide/conf.py
@@ -26,6 +26,6 @@ html_title = project
 
 intersphinx_mapping = {
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
-    "qiskit-ibm-runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
 }

--- a/docs_guide/requirements-extra.txt
+++ b/docs_guide/requirements-extra.txt
@@ -1,4 +1,4 @@
 # this file contains extra requirements for building the docs guide in addition to `requirements-dev.txt`
-qiskit-terra
+qiskit~=1.0
 pylatexenc
 sphinx_toolbox

--- a/docs_guide/sphinx_guide/how_to_add_external_links.rst
+++ b/docs_guide/sphinx_guide/how_to_add_external_links.rst
@@ -13,11 +13,11 @@ There are two types of files
 ``.rst``
 =========
 
-In order to link to an external page you have to write ```text of your link <your_url>`_``. For example, you can link to `Qiskit's page <https://qiskit.org/>`_ by writing:
+In order to link to an external page you have to write ```text of your link <your_url>`_``. For example, you can link to `IBM Quantum documentation <https://docs.quantum.ibm.com>`_ by writing:
 
 .. code-block:: text
 
-    `Qiskit's page <https://qiskit.org/>`_
+    `IBM Quantum documentation <https://docs.quantum.ibm.com>`_
 
 .. note::
 
@@ -27,11 +27,11 @@ In order to link to an external page you have to write ```text of your link <you
 ``.ipynb``
 ===========
 
-If your file is a Jupyter notebook, what you have to write to link to a page is ``[text of your link](your_url)``. If you want to link to `Qiskit's page <https://qiskit.org/>`_ you can write:
+If your file is a Jupyter notebook, what you have to write to link to a page is ``[text of your link](your_url)``. If you want to link to `IBM Quantum Documentation <https://docs.quantum.ibm.com>`_ you can write:
 
 .. code-block:: text
 
-    [Qiskit's page](https://qiskit.org/)
+    [Qiskit's page](https://docs.quantum.ibm.com)
 
 
 .. warning::

--- a/docs_guide/sphinx_guide/how_to_cross-reference.rst
+++ b/docs_guide/sphinx_guide/how_to_cross-reference.rst
@@ -95,7 +95,7 @@ For example, if you want to add Qiskit's and Sphinx's documentation you can writ
 .. code-block:: python
 
     intersphinx_mapping = {
-        "qiskit": ("https://qiskit.org/documentation/", None),
+        "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
         "sphinx": ("https://www.sphinx-doc.org/en/master/", None)
     }
 

--- a/docs_guide/sphinx_guide/sphinx.rst
+++ b/docs_guide/sphinx_guide/sphinx.rst
@@ -35,5 +35,4 @@ Sphinx also offers a wide array of extensions that make creating docs much easie
 
 
 Another Sphinx characteristic we use extensively is the ability to customize an HTML theme, so we have our own theme called
-`qiskit_sphinx_theme <https://github.com/Qiskit/qiskit_sphinx_theme>`_, that gives `qiskit.org <https://qiskit.org>`_ and any locally built Qiskit docs their
-characteristic appearance.
+`qiskit_sphinx_theme <https://github.com/Qiskit/qiskit_sphinx_theme>`_, that gives a consistent theme for projects in the `Qiskit Ecosystem <https://qiskit.github.io/ecosystem/#>`__.

--- a/docs_guide/tutorials/tutorials_examples.rst
+++ b/docs_guide/tutorials/tutorials_examples.rst
@@ -8,6 +8,6 @@ examples to create your own tutorials.
 Qiskit IBM Runtime
 ==================
 
-* :doc:`qiskit-ibm-runtime:tutorials/grover_with_sampler`
-* :doc:`qiskit-ibm-runtime:tutorials/chsh_with_estimator`
-* :doc:`qiskit-ibm-runtime:tutorials/vqe_with_estimator`
+* https://github.com/Qiskit/qiskit-ibm-runtime/blob/stable/0.16/docs/tutorials/grover_with_sampler.ipynb
+* https://github.com/Qiskit/qiskit-ibm-runtime/blob/stable/0.16/docs/tutorials/chsh_with_estimator.ipynb
+* https://github.com/Qiskit/qiskit-ibm-runtime/blob/stable/0.16/docs/tutorials/vqe_with_estimator.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 license = { file = "LICENSE" }
-authors = [{ name = "Qiskit Development Team", email = "hello@qiskit.org" }]
+authors = [{ name = "Qiskit Development Team", email = "qiskit@us.ibm.com" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",

--- a/src/qiskit_sphinx_theme/assets/styles/_layout.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_layout.scss
@@ -15,7 +15,7 @@
 // doesn't increase the entry size. It also keeps the page contents fixed at 46em.
 //
 // Instead, we always keep the side bars the same size, and we expand the main page
-// contents. This is a better use of screen real estate and is more consistent with qiskit.org.
+// contents. This is a better use of screen real estate.
 //
 // But, we only expand the main contents up to 60em because best practices recommend not having
 // prose-heavy sites spread content over too long:

--- a/src/qiskit_sphinx_theme/assets/styles/_tables.scss
+++ b/src/qiskit_sphinx_theme/assets/styles/_tables.scss
@@ -12,7 +12,7 @@
  */
 
 body {
-  // Use the same table header color as qiskit.org.
+  // Use the same table header color previously used on qiskit.org.
   --color-table-header-background: #dde1e6;
 }
 

--- a/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_brand.html
+++ b/src/qiskit_sphinx_theme/theme/qiskit-sphinx-theme/custom_templates/sidebar_brand.html
@@ -6,7 +6,7 @@
 {#- We default to showing a Qiskit Ecosystem logo -#}
 {%- if not logo_url and not theme_light_logo and not theme_dark_logo and not theme_disable_ecosystem_logo -%}
 <div class="sidebar-brand">
-  <a href="https://www.qiskit.org/ecosystem">
+  <a href="https://qiskit.github.io/ecosystem/">
     <div class="sidebar-logo-container">
       <img class="sidebar-logo" src="{{ pathto('_static/images/ecosystem-logo.svg', 1) }}" alt="Qiskit Ecosystem logo"/>
     </div>


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit_sphinx_theme/issues/588 and fixes CI breaking due to the release of Qiskit 1.0.

The major remaining reference is our guidance on how to deploy docs projects, which is tracked by https://github.com/Qiskit/qiskit_sphinx_theme/issues/591.