### PR TITLE
Bump furo to 2024.1.29 (Cherry-pick of #594)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
 dependencies = [
     "docutils",
     # Keep in sync with Furo's constraint.
-    "sphinx>=6.0",
+    "sphinx>=6.0,<8.0",
     # Remove jQuery once we get rid of the Pytorch theme.
     "sphinxcontrib-jquery",
     # See CONTRIBUTING.md for how to upgrade Furo.
-    "furo==2023.8.19",
+    "furo==2024.1.29",
 ]
 
 [project.entry-points."sphinx.html_themes"]


### PR DESCRIPTION
Update `furo` from 2023.8.19 to 2024.1.29. Resolves #567.