### PR TITLE
Publishing to PyPI with trusted publishers (Cherry-pick of #570)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ jobs:
   wheel-build:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     if: github.repository_owner == 'Qiskit'
     steps:
       - uses: actions/checkout@v3
@@ -15,7 +18,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install Deps
-        run: pip install -U twine build
+        run: pip install -U build
       - name: Build Artifacts
         run: |
           python -m build
@@ -23,8 +26,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./dist/qiskit*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run: twine upload dist/qiskit*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          path: ./dist/qiskit*


### PR DESCRIPTION
This PR changes the wheel-build job to publish the package to PyPI with the trusted publisher mechanism following the steps in https://docs.pypi.org/trusted-publishers/using-a-publisher/ and https://github.com/Qiskit/rustworkx/pull/1001/files